### PR TITLE
added convert_graph statement to erdos_renyi_modularity

### DIFF
--- a/cdlib/evaluation/fitness.py
+++ b/cdlib/evaluation/fitness.py
@@ -612,7 +612,7 @@ def erdos_renyi_modularity(graph, communities, **kwargs):
 
     1. Erdos, P., & Renyi, A. (1959). `On random graphs I. <https://gnunet.org/sites/default/files/Erd%C5%91s%20%26%20R%C3%A9nyi%20-%20On%20Random%20Graphs.pdf/>`_ Publ. Math. Debrecen, 6, 290-297.
     """
-
+    graph = convert_graph_formats(graph, nx.Graph)
     m = graph.number_of_edges()
     n = graph.number_of_nodes()
     q = 0


### PR DESCRIPTION
### Identify the Bug

Not worth opening an issue, lack of 'convert_graph_formats' in cdlib.evaluation.erdos_renyi_modularity() was throwing an error due to the Networkx method 'number_of_edges' being called on an igraph object.

### Description of the Change

Single line addition of a 'convert_graph_formats' call.

### Alternate Designs

N/A

### Possible Drawbacks

N/A

### Verification Process



N/A

### Release Notes


- Fixed a bug that caused the Erdos-Renyi modularity function to fail
