### PR TITLE
Correction in doc ensemble.rst

### DIFF
--- a/docs/reference/ensemble.rst
+++ b/docs/reference/ensemble.rst
@@ -13,7 +13,7 @@ Configuration Objects
 
 Ranges can be specified to automate the execution of a same method while varying (part of) its inputs.
 
-``BoolParameters`` allows to specify ranges for numeric parameters, while ``BoolParamters`` for boolean ones.
+``Parameter`` allows to specify ranges for numeric parameters, while ``BoolParamter`` for boolean ones.
 
 .. autosummary::
     :toctree: generated/


### PR DESCRIPTION
### Description of the Change

In https://github.com/GiulioRossetti/cdlib/blob/master/docs/reference/ensemble.rst file there is a little error specifying the arguments. It is saying that BoolParameter class instead Parameters class allows to specify ranges for numeric parameters. Fix #85 .


### Release Notes

Not applicable.