### PR TITLE
fix for keeping directions by default and igraph convert bug

### DIFF
--- a/cdlib/algorithms/attribute_clustering.py
+++ b/cdlib/algorithms/attribute_clustering.py
@@ -12,14 +12,14 @@ from cdlib.algorithms.internal.ILouvain import ML2
 __all__ = ['eva', 'ilouvain']
 
 
-def eva(g, labels, weight='weight', resolution=1., randomize=False, alpha=0.5):
+def eva(g_original, labels, weight='weight', resolution=1., randomize=False, alpha=0.5):
 
     """
        The Eva algorithm extends the Louvain approach in order to deal with the attributes of the nodes (aka Louvain Extended to Vertex Attributes).
        It optimizes - combining them linearly - two quality functions, a structural and a clustering one, namely Newman's modularity and purity, estimated as the product of the frequencies of the most frequent labels carried by the nodes within the communities.
        A parameter alpha tunes the importance of the two functions: an high value of alpha favors the clustering criterion instead of the structural one.
 
-       :param g: a networkx/igraph object
+       :param g_original: a networkx/igraph object
        :param labels: dictionary specifying for each node (key) a dict (value) specifying the name attribute (key) and its value (value)
        :param weight: str, optional the key in graph to use as weight. Default to 'weight'
        :param resolution: double, optional  Will change the size of the communities, default to 1.
@@ -47,7 +47,7 @@ def eva(g, labels, weight='weight', resolution=1., randomize=False, alpha=0.5):
        .. note:: Reference implementation: https://github.com/GiulioRossetti/Eva/tree/master/Eva
        """
 
-    g = convert_graph_formats(g, nx.Graph)
+    g = convert_graph_formats(g_original, nx.Graph)
     nx.set_node_attributes(g, labels)
 
     coms, coms_labels = Eva.eva_best_partition(g, weight=weight, resolution=resolution, randomize=randomize, alpha=alpha)
@@ -58,16 +58,16 @@ def eva(g, labels, weight='weight', resolution=1., randomize=False, alpha=0.5):
         coms_to_node[c].append(n)
 
     coms_eva = [list(c) for c in coms_to_node.values()]
-    return AttrNodeClustering(coms_eva, g, "Eva", coms_labels, method_parameters={"weight": weight, "resolution": resolution,
+    return AttrNodeClustering(coms_eva, g_original, "Eva", coms_labels, method_parameters={"weight": weight, "resolution": resolution,
                                                                          "randomize": randomize, "alpha":alpha})
 
 
-def ilouvain(g, labels, id):
+def ilouvain(g_original, labels, id):
     """
           The I-Louvain algorithm extends the Louvain approach in order to deal only with the scalar attributes of the nodes.
           It optimizes Newman's modularity combined with an entropy measure.
 
-          :param g: a networkx/igraph object
+          :param g_original: a networkx/igraph object
           :param labels: dictionary specifying for each node (key) a dict (value) specifying the name attribute (key) and its value (value)
           :param id: a dict specifying the node id
           :return: AttrNodeClustering object
@@ -94,7 +94,7 @@ def ilouvain(g, labels, id):
           """
 
 
-    g = convert_graph_formats(g, nx.Graph)
+    g = convert_graph_formats(g_original, nx.Graph)
     nx.set_node_attributes(g, labels)
     id = dict()
     for n in g.nodes():
@@ -110,4 +110,4 @@ def ilouvain(g, labels, id):
 
     coms_ilouv = [list(c) for c in coms_to_node.values()]
 
-    return AttrNodeClustering(coms_ilouv, g, "ILouvain")
+    return AttrNodeClustering(coms_ilouv, g_original, "ILouvain")

--- a/cdlib/algorithms/biparitte_clustering.py
+++ b/cdlib/algorithms/biparitte_clustering.py
@@ -7,11 +7,11 @@ from cdlib.utils import convert_graph_formats
 __all__ = ['bimlpa']
 
 
-def bimlpa(g, theta=0.3, lambd=7):
+def bimlpa(g_original, theta=0.3, lambd=7):
     """
     BiMLPA is designed to detect the many-to-many correspondence community in bipartite networks using multi-label propagation algorithm.
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param theta: Label weights threshold. Default 0.3.
     :param lambd: The max number of labels. Default 7.
     :return: BiNodeClustering object
@@ -32,11 +32,11 @@ def bimlpa(g, theta=0.3, lambd=7):
     """
     from BiMLPA import BiMLPA_SqrtDeg, relabeling, output_community
 
-    g = convert_graph_formats(g, nx.Graph)
+    g = convert_graph_formats(g_original, nx.Graph)
 
     bimlpa = BiMLPA_SqrtDeg(g, theta, lambd)
     bimlpa.start()
     relabeling(g)
     top_coms, bottom_coms = output_community(g)
 
-    return BiNodeClustering(top_coms, bottom_coms, g, "BiMLPA", method_parameters={"theta": theta, "lambd": lambd})
+    return BiNodeClustering(top_coms, bottom_coms, g_original, "BiMLPA", method_parameters={"theta": theta, "lambd": lambd})

--- a/cdlib/algorithms/crisp_partition.py
+++ b/cdlib/algorithms/crisp_partition.py
@@ -43,12 +43,12 @@ __all__ = ["louvain", "leiden", "rb_pots", "rber_pots", "cpm", "significance_com
            "markov_clustering", "edmot"]
 
 
-def girvan_newman(g, level):
+def girvan_newman(g_original, level):
     """
     The Girvan–Newman algorithm detects communities by progressively removing edges from the original graph.
     The algorithm removes the "most valuable" edge, traditionally the edge with the highest betweenness centrality, at each step. As the graph breaks down into pieces, the tightly knit community structure is exposed and the result can be depicted as a dendrogram.
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param level: the level where to cut the dendrogram
     :return: NodeClustering object
 
@@ -64,7 +64,7 @@ def girvan_newman(g, level):
     Girvan, Michelle, and Mark EJ Newman. `Community structure in social and biological networks. <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC122977/>`_ Proceedings of the national academy of sciences 99.12 (2002): 7821-7826.
     """
 
-    g = convert_graph_formats(g, nx.Graph)
+    g = convert_graph_formats(g_original, nx.Graph)
 
     gn_hierarchy = nx.algorithms.community.girvan_newman(g)
     coms = []
@@ -76,15 +76,15 @@ def girvan_newman(g, level):
     for c in coms:
         communities.append(list(c))
 
-    return NodeClustering(communities, g, "Girvan Newman", method_parameters={"level": level})
+    return NodeClustering(communities, g_original, "Girvan Newman", method_parameters={"level": level})
 
 
-def em(g, k):
+def em(g_original, k):
     """
     EM is based on based on a mixture model.
     The algorithm uses the expectation–maximization algorithm to detect structure in networks.
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param k: the number of desired communities
     :return: NodeClustering object
 
@@ -100,7 +100,7 @@ def em(g, k):
     Newman, Mark EJ, and Elizabeth A. Leicht. `Mixture community and exploratory analysis in networks.  <https://www.pnas.org/content/104/23/9564/>`_  Proceedings of the National Academy of Sciences 104.23 (2007): 9564-9569.
     """
 
-    g = convert_graph_formats(g, nx.Graph)
+    g = convert_graph_formats(g_original, nx.Graph)
     g, maps = nx_node_integer_mapping(g)
 
     algorithm = EM_nx(g, k)
@@ -114,17 +114,17 @@ def em(g, k):
     else:
         communities = [list(c) for c in coms]
 
-    return NodeClustering(communities, g, "EM", method_parameters={"k": k})
+    return NodeClustering(communities, g_original, "EM", method_parameters={"k": k})
 
 
-def scan(g, epsilon, mu):
+def scan(g_original, epsilon, mu):
     """
     SCAN (Structural Clustering Algorithm for Networks) is an algorithm which detects clusters, hubs and outliers in networks.
     It clusters vertices based on a structural similarity measure.
     The method uses the neighborhood of the vertices as clustering criteria instead of only their direct connections.
     Vertices are grouped into the clusters by how they share neighbors.
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param epsilon: the minimum threshold to assigning cluster membership
     :param mu: minimum number of neineighbors with a structural similarity that exceeds the threshold epsilon
     :return: NodeClustering object
@@ -141,20 +141,20 @@ def scan(g, epsilon, mu):
     Xu, X., Yuruk, N., Feng, Z., & Schweiger, T. A. (2007, August). `Scan: a structural clustering algorithm for networks. <http://www1.se.cuhk.edu.hk/~hcheng/seg5010/slides/p824-xu.pdf/>`_ In Proceedings of the 13th ACM SIGKDD international conference on Knowledge discovery and data mining (pp. 824-833)
     """
 
-    g = convert_graph_formats(g, nx.Graph)
+    g = convert_graph_formats(g_original, nx.Graph)
 
     algorithm = SCAN_nx(g, epsilon, mu)
     coms = algorithm.execute()
-    return NodeClustering(coms, g, "SCAN", method_parameters={"epsilon": epsilon,
+    return NodeClustering(coms, g_original, "SCAN", method_parameters={"epsilon": epsilon,
                                                               "mu": mu})
 
 
-def gdmp2(g, min_threshold=0.75):
+def gdmp2(g_original, min_threshold=0.75):
     """
     Gdmp2 is a method for identifying a set of dense subgraphs of a given sparse graph.
     It is inspired by an effective technique designed for a similar problem—matrix blocking, from a different discipline (solving linear systems).
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param min_threshold:  the minimum density threshold parameter to control the density of the output subgraphs, default 0.75
     :return: NodeClustering object
 
@@ -173,7 +173,7 @@ def gdmp2(g, min_threshold=0.75):
     .. note:: Reference implementation: https://github.com/imabhishekl/CSC591_Community_Detection
     """
 
-    g = convert_graph_formats(g, nx.Graph)
+    g = convert_graph_formats(g_original, nx.Graph)
     g, maps = nx_node_integer_mapping(g)
 
     coms = GDMP2(g, min_threshold)
@@ -186,15 +186,15 @@ def gdmp2(g, min_threshold=0.75):
     else:
         communities = coms
 
-    return NodeClustering(communities, g, "GDMP2", method_parameters={"min_threshold": min_threshold})
+    return NodeClustering(communities, g_original, "GDMP2", method_parameters={"min_threshold": min_threshold})
 
 
-def spinglass(g):
+def spinglass(g_original):
     """
     Spinglass relies on an analogy between a very popular statistical mechanic model called Potts spin glass, and the community structure.
     It applies the simulated annealing optimization technique on this model to optimize the modularity.
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :return: NodeClustering object
 
     :Example:
@@ -211,22 +211,22 @@ def spinglass(g):
     if ig is None:
         raise ModuleNotFoundError("Optional dependency not satisfied: install igraph to use the selected feature.")
 
-    g = convert_graph_formats(g, ig.Graph)
+    g = convert_graph_formats(g_original, ig.Graph)
     coms = g.community_spinglass()
     communities = []
 
     for c in coms:
         communities.append([g.vs[x]['name'] for x in c])
 
-    return NodeClustering(communities, g, "Spinglass", method_parameters={"": ""})
+    return NodeClustering(communities, g_original, "Spinglass", method_parameters={"": ""})
 
 
-def eigenvector(g):
+def eigenvector(g_original):
     """
     Newman's leading eigenvector method for detecting community structure based on modularity.
     This is the proper internal of the recursive, divisive algorithm: each split is done by maximizing the modularity regarding the original network.
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :return: NodeClustering object
 
     :Example:
@@ -244,20 +244,20 @@ def eigenvector(g):
     if ig is None:
         raise ModuleNotFoundError("Optional dependency not satisfied: install igraph to use the selected feature.")
 
-    g = convert_graph_formats(g, ig.Graph)
+    g = convert_graph_formats(g_original, ig.Graph)
     coms = g.community_leading_eigenvector()
 
     communities = [g.vs[x]['name'] for x in coms]
 
-    return NodeClustering(communities, g, "Eigenvector", method_parameters={"":""})
+    return NodeClustering(communities, g_original, "Eigenvector", method_parameters={"":""})
 
 
-def agdl(g, number_communities, number_neighbors, kc, a):
+def agdl(g_original, number_communities, number_neighbors, kc, a):
     """
     AGDL is a graph-based agglomerative algorithm, for clustering high-dimensional data.
     The algorithm uses  the indegree and outdegree to characterize the affinity between two clusters.
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param number_communities: number of communities
     :param number_neighbors: Number of neighbors to use for KNN
     :param kc: size of the neighbor set for each cluster
@@ -278,7 +278,7 @@ def agdl(g, number_communities, number_neighbors, kc, a):
     .. note:: Reference implementation: https://github.com/myungjoon/GDL
     """
 
-    g = convert_graph_formats(g, nx.Graph)
+    g = convert_graph_formats(g_original, nx.Graph)
 
     communities = Agdl(g, number_communities, number_neighbors, kc, a)
     nodes = {k: v for k, v in enumerate(g.nodes())}
@@ -286,12 +286,12 @@ def agdl(g, number_communities, number_neighbors, kc, a):
     for com in communities:
         coms.append([nodes[n] for n in com])
 
-    return NodeClustering(coms, g, "AGDL", method_parameters={"number_communities": number_communities,
+    return NodeClustering(coms, g_original, "AGDL", method_parameters={"number_communities": number_communities,
                                                               "number_neighbors": number_neighbors,
                                                               "kc": kc, "a": a})
 
 
-def louvain(g, weight='weight', resolution=1., randomize=False):
+def louvain(g_original, weight='weight', resolution=1., randomize=False):
     """
     Louvain  maximizes a modularity score for each community.
     The algorithm optimises the modularity in two elementary phases:
@@ -301,7 +301,7 @@ def louvain(g, weight='weight', resolution=1., randomize=False):
     In the aggregation phase, an aggregate network is created based on the partition obtained in the local moving phase.
     Each community in this partition becomes a node in the aggregate network. The two phases are repeated until the quality function cannot be increased further.
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param weight: str, optional the key in graph to use as weight. Default to 'weight'
     :param resolution: double, optional  Will change the size of the communities, default to 1.
     :param randomize:  boolean, optional  Will randomize the node evaluation order and the community evaluation  order to get different partitions at each call, default False
@@ -322,7 +322,7 @@ def louvain(g, weight='weight', resolution=1., randomize=False):
     .. note:: Reference implementation: https://github.com/taynaud/python-louvain
     """
 
-    g = convert_graph_formats(g, nx.Graph)
+    g = convert_graph_formats(g_original, nx.Graph)
 
     coms = louvain_modularity.best_partition(g, weight=weight, resolution=resolution, randomize=randomize)
 
@@ -332,11 +332,11 @@ def louvain(g, weight='weight', resolution=1., randomize=False):
         coms_to_node[c].append(n)
 
     coms_louvain = [list(c) for c in coms_to_node.values()]
-    return NodeClustering(coms_louvain, g, "Louvain", method_parameters={"weight": weight, "resolution": resolution,
+    return NodeClustering(coms_louvain, g_original, "Louvain", method_parameters={"weight": weight, "resolution": resolution,
                                                                          "randomize": randomize})
 
 
-def leiden(g, initial_membership=None, weights=None):
+def leiden(g_original, initial_membership=None, weights=None):
     """
     The Leiden algorithm is an improvement of the Louvain algorithm.
     The Leiden algorithm consists of three phases:
@@ -344,7 +344,7 @@ def leiden(g, initial_membership=None, weights=None):
     (2) refinement of the partition
     (3) aggregation of the network based on the refined partition, using the non-refined partition to create an initial partition for the aggregate network.
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param initial_membership:  list of int Initial membership for the partition. If :obj:`None` then defaults to a singleton partition. Deafault None
     :param weights: list of double, or edge attribute Weights of edges. Can be either an iterable or an edge attribute. Deafault None
     :return: NodeClustering object
@@ -367,17 +367,17 @@ def leiden(g, initial_membership=None, weights=None):
         raise ModuleNotFoundError("Optional dependency not satisfied: install igraph and leidenalg to use the "
                                   "selected feature.")
 
-    g = convert_graph_formats(g, ig.Graph)
+    g = convert_graph_formats(g_original, ig.Graph)
 
     part = leidenalg.find_partition(g, leidenalg.ModularityVertexPartition,
                                     initial_membership=initial_membership, weights=weights
                                     )
     coms = [g.vs[x]['name'] for x in part]
-    return NodeClustering(coms, g, "Leiden", method_parameters={"initial_membership": initial_membership,
+    return NodeClustering(coms, g_original, "Leiden", method_parameters={"initial_membership": initial_membership,
                                                                 "weights": weights})
 
 
-def rb_pots(g, initial_membership=None, weights=None, resolution_parameter=1):
+def rb_pots(g_original, initial_membership=None, weights=None, resolution_parameter=1):
     """
     Rb_pots is a model where the quality function to optimize is:
 
@@ -392,7 +392,7 @@ def rb_pots(g, initial_membership=None, weights=None, resolution_parameter=1):
     Note that this is the same of Leiden algorithm when setting :math:`\\gamma=1` and normalising by :math:`2m`, or :math:`m` for directed graphs.
 
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param initial_membership:  list of int Initial membership for the partition. If :obj:`None` then defaults to a singleton partition. Deafault None
     :param weights: list of double, or edge attribute Weights of edges. Can be either an iterable or an edge attribute. Deafault None
     :param resolution_parameter: double >0 A parameter value controlling the coarseness of the clustering. Higher resolutions lead to more communities, while lower resolutions lead to fewer communities. Default 1
@@ -416,18 +416,18 @@ def rb_pots(g, initial_membership=None, weights=None, resolution_parameter=1):
     if ig is None:
         raise ModuleNotFoundError("Optional dependency not satisfied: install igraph to use the selected feature.")
 
-    g = convert_graph_formats(g, ig.Graph)
+    g = convert_graph_formats(g_original, ig.Graph)
 
     part = leidenalg.find_partition(g, leidenalg.RBConfigurationVertexPartition,
                                     resolution_parameter=resolution_parameter,
                                     initial_membership=initial_membership, weights=weights)
     coms = [g.vs[x]['name'] for x in part]
-    return NodeClustering(coms, g, "RB Pots", method_parameters={"initial_membership": initial_membership,
+    return NodeClustering(coms, g_original, "RB Pots", method_parameters={"initial_membership": initial_membership,
                                                                  "weights": weights,
                                                                  "resolution_parameter": resolution_parameter})
 
 
-def rber_pots(g, initial_membership=None, weights=None, node_sizes=None, resolution_parameter=1):
+def rber_pots(g_original, initial_membership=None, weights=None, node_sizes=None, resolution_parameter=1):
     """
     rber_pots is a  model where the quality function to optimize is:
 
@@ -436,7 +436,7 @@ def rber_pots(g, initial_membership=None, weights=None, node_sizes=None, resolut
     where :math:`A` is the adjacency matrix,  :math:`p = \\frac{m}{\\binom{n}{2}}` is the overall density of the graph, :math:`\\sigma_i` denotes the community of node :math:`i`, :math:`\\delta(\\sigma_i, \\sigma_j) = 1` if  :math:`\\sigma_i = \\sigma_j` and `0` otherwise, and, finally :math:`\\gamma` is a resolution parameter.
 
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param initial_membership:  list of int Initial membership for the partition. If :obj:`None` then defaults to a singleton partition. Deafault None
     :param weights: list of double, or edge attribute Weights of edges. Can be either an iterable or an edge attribute. Deafault None
     :param node_sizes: list of int, or vertex attribute Sizes of nodes are necessary to know the size of communities in aggregate graphs. Usually this is set to 1 for all nodes, but in specific cases  this could be changed. Deafault None
@@ -462,7 +462,7 @@ def rber_pots(g, initial_membership=None, weights=None, node_sizes=None, resolut
     if ig is None:
         raise ModuleNotFoundError("Optional dependency not satisfied: install igraph to use the selected feature.")
 
-    g = convert_graph_formats(g, ig.Graph)
+    g = convert_graph_formats(g_original, ig.Graph)
 
     part = leidenalg.find_partition(g, leidenalg.RBERVertexPartition,
                                     resolution_parameter=resolution_parameter,
@@ -470,12 +470,12 @@ def rber_pots(g, initial_membership=None, weights=None, node_sizes=None, resolut
                                     node_sizes=node_sizes,
                                     )
     coms = [g.vs[x]['name'] for x in part]
-    return NodeClustering(coms, g, "RBER Pots", method_parameters={"initial_membership": initial_membership,
+    return NodeClustering(coms, g_original, "RBER Pots", method_parameters={"initial_membership": initial_membership,
                                                                    "weights": weights, "node_sizes": node_sizes,
                                                                    "resolution_parameter": resolution_parameter})
 
 
-def cpm(g, initial_membership=None, weights=None, node_sizes=None, resolution_parameter=1):
+def cpm(g_original, initial_membership=None, weights=None, node_sizes=None, resolution_parameter=1):
     """
     CPM is a model where the quality function to optimize is:
 
@@ -494,7 +494,7 @@ def cpm(g, initial_membership=None, weights=None, node_sizes=None, resolution_pa
     density, and as such defines communities. Finally, the definition of a community is in a sense independent of the actual graph, which is not the case for any of the other methods.
 
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param initial_membership:  list of int Initial membership for the partition. If :obj:`None` then defaults to a singleton partition. Deafault None
     :param weights: list of double, or edge attribute Weights of edges. Can be either an iterable or an edge attribute. Deafault None
     :param node_sizes: list of int, or vertex attribute Sizes of nodes are necessary to know the size of communities in aggregate graphs. Usually this is set to 1 for all nodes, but in specific cases  this could be changed. Deafault None
@@ -520,18 +520,18 @@ def cpm(g, initial_membership=None, weights=None, node_sizes=None, resolution_pa
     if ig is None:
         raise ModuleNotFoundError("Optional dependency not satisfied: install igraph to use the selected feature.")
 
-    g = convert_graph_formats(g, ig.Graph)
+    g = convert_graph_formats(g_original, ig.Graph)
 
     part = leidenalg.find_partition(g, leidenalg.CPMVertexPartition,
                                     resolution_parameter=resolution_parameter, initial_membership=initial_membership,
                                     weights=weights, node_sizes=node_sizes, )
     coms = [g.vs[x]['name'] for x in part]
-    return NodeClustering(coms, g, "CPM", method_parameters={"initial_membership": initial_membership,
+    return NodeClustering(coms, g_original, "CPM", method_parameters={"initial_membership": initial_membership,
                                                              "weights": weights, "node_sizes": node_sizes,
                                                              "resolution_parameter": resolution_parameter})
 
 
-def significance_communities(g, initial_membership=None, node_sizes=None):
+def significance_communities(g_original, initial_membership=None, node_sizes=None):
     """
     Significance_communities is a model where the quality function to optimize is:
 
@@ -543,7 +543,7 @@ def significance_communities(g, initial_membership=None, node_sizes=None):
     .. warning:: This method is not suitable for weighted graphs.
 
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param initial_membership:  list of int Initial membership for the partition. If :obj:`None` then defaults to a singleton partition. Deafault None
     :param node_sizes: list of int, or vertex attribute Sizes of nodes are necessary to know the size of communities in aggregate graphs. Usually this is set to 1 for all nodes, but in specific cases  this could be changed. Deafault None
     :return: NodeClustering object
@@ -566,16 +566,16 @@ def significance_communities(g, initial_membership=None, node_sizes=None):
     if ig is None:
         raise ModuleNotFoundError("Optional dependency not satisfied: install igraph to use the selected feature.")
 
-    g = convert_graph_formats(g, ig.Graph)
+    g = convert_graph_formats(g_original, ig.Graph)
 
     part = leidenalg.find_partition(g, leidenalg.SignificanceVertexPartition, initial_membership=initial_membership,
                                     node_sizes=node_sizes)
     coms = [g.vs[x]['name'] for x in part]
-    return NodeClustering(coms, g, "Significance", method_parameters={"initial_membership": initial_membership,
+    return NodeClustering(coms, g_original, "Significance", method_parameters={"initial_membership": initial_membership,
                                                                       "node_sizes": node_sizes})
 
 
-def surprise_communities(g, initial_membership=None, weights=None, node_sizes=None):
+def surprise_communities(g_original, initial_membership=None, weights=None, node_sizes=None):
     """
 
     Surprise_communities is a model where the quality function to optimize is:
@@ -589,7 +589,7 @@ def surprise_communities(g, initial_membership=None, weights=None, node_sizes=No
     For directed graphs we can multiplying the binomials by 2, and this leaves :math:`\\langle q \\rangle` unchanged, so that we can simply use the same
     formulation.  For weighted graphs we can simply count the total internal weight instead of the total number of edges for :math:`q` , while :math:`\\langle q \\rangle` remains unchanged.
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param initial_membership:  list of int Initial membership for the partition. If :obj:`None` then defaults to a singleton partition. Deafault None
     :param weights: list of double, or edge attribute Weights of edges. Can be either an iterable or an edge attribute. Deafault None
     :param node_sizes: list of int, or vertex attribute Sizes of nodes are necessary to know the size of communities in aggregate graphs. Usually this is set to 1 for all nodes, but in specific cases  this could be changed. Deafault None
@@ -613,21 +613,21 @@ def surprise_communities(g, initial_membership=None, weights=None, node_sizes=No
     if ig is None:
         raise ModuleNotFoundError("Optional dependency not satisfied: install igraph to use the selected feature.")
 
-    g = convert_graph_formats(g, ig.Graph)
+    g = convert_graph_formats(g_original, ig.Graph)
 
     part = leidenalg.find_partition(g, leidenalg.SurpriseVertexPartition, initial_membership=initial_membership,
                                     weights=weights, node_sizes=node_sizes)
     coms = [g.vs[x]['name'] for x in part]
-    return NodeClustering(coms, g, "Surprise", method_parameters={"initial_membership": initial_membership,
+    return NodeClustering(coms, g_original, "Surprise", method_parameters={"initial_membership": initial_membership,
                                                                   "weights": weights, "node_sizes": node_sizes})
 
 
-def greedy_modularity(g, weight=None):
+def greedy_modularity(g_original, weight=None):
     """
     The CNM algorithm uses the modularity to find the communities strcutures.
     At every step of the algorithm two communities that contribute maximum positive value to global modularity are merged.
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param weight: list of double, or edge attribute Weights of edges. Can be either an iterable or an edge attribute. Deafault None
     :return: NodeClustering object
 
@@ -642,19 +642,19 @@ def greedy_modularity(g, weight=None):
 
     Clauset, A., Newman, M. E., & Moore, C. `Finding community structure in very large networks. <http://ece-research.unm.edu/ifis/papers/community-moore.pdf/>`_ Physical Review E 70(6), 2004
     """
-    g = convert_graph_formats(g, nx.Graph)
+    g = convert_graph_formats(g_original, nx.Graph)
 
     coms = nx.algorithms.community.greedy_modularity_communities(g, weight)
     coms = [list(x) for x in coms]
-    return NodeClustering(coms, g, "Greedy Modularity", method_parameters={"weight": weight})
+    return NodeClustering(coms, g_original, "Greedy Modularity", method_parameters={"weight": weight})
 
 
-def infomap(g):
+def infomap(g_original):
     """
     Infomap is based on ideas of information theory.
     The algorithm uses the probability flow of random walks on a network as a proxy for information flows in the real system and it decomposes the network into modules by compressing a description of the probability flow.
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :return: NodeClustering object
 
     :Example:
@@ -674,7 +674,7 @@ def infomap(g):
     if imp is None:
         raise ModuleNotFoundError("Optional dependency not satisfied: install infomap to use the selected feature.")
 
-    g = convert_graph_formats(g, nx.Graph)
+    g = convert_graph_formats(g_original, nx.Graph)
 
     g1 = nx.convert_node_labels_to_integers(g, label_attribute="name")
     name_map = nx.get_node_attributes(g1, 'name')
@@ -695,15 +695,15 @@ def infomap(g):
                 coms_to_node[module].append(nm)
 
     coms_infomap = [list(c) for c in coms_to_node.values()]
-    return NodeClustering(coms_infomap, g, "Infomap", method_parameters={"":""})
+    return NodeClustering(coms_infomap, g_original, "Infomap", method_parameters={"":""})
 
 
-def walktrap(g):
+def walktrap(g_original):
     """
     walktrap is an approach based on random walks.
     The general idea is that if you perform random walks on the graph, then the walks are more likely to stay within the same community because there are only a few edges that lead outside a given community. Walktrap runs short random walks and uses the results of these random walks to merge separate communities in a bottom-up manner.
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :return: NodeClusterint object
 
     :Example:
@@ -721,17 +721,17 @@ def walktrap(g):
     if ig is None:
         raise ModuleNotFoundError("Optional dependency not satisfied: install igraph to use the selected feature.")
 
-    g = convert_graph_formats(g, ig.Graph)
+    g = convert_graph_formats(g_original, ig.Graph)
     coms = g.community_walktrap().as_clustering()
     communities = []
 
     for c in coms:
         communities.append([g.vs[x]['name'] for x in c])
 
-    return NodeClustering(communities, g, "Walktrap", method_parameters={"":""})
+    return NodeClustering(communities, g_original, "Walktrap", method_parameters={"":""})
 
 
-def label_propagation(g):
+def label_propagation(g_original):
     """
     The Label Propagation algorithm (LPA) detects communities using network structure alone.
     The algorithm doesn’t require a pre-defined objective function or prior information about the communities.
@@ -741,7 +741,7 @@ def label_propagation(g):
     -At every iteration of propagation, each node updates its label to the one that the maximum numbers of its neighbours belongs to. Ties are broken uniformly and randomly.
     -LPA reaches convergence when each node has the majority label of its neighbours.
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :return: EdgeClustering object
 
     :Example:
@@ -756,21 +756,21 @@ def label_propagation(g):
     Raghavan, U. N., Albert, R., & Kumara, S. (2007). `Near linear time algorithm to detect community structures in large-scale networks. <http://www.leonidzhukov.net/hse/2017/networks/papers/raghavan2007.pdf/>`_ Physical review E, 76(3), 036106.
     """
 
-    g = convert_graph_formats(g, nx.Graph)
+    g = convert_graph_formats(g_original, nx.Graph)
 
     coms = list(nx.algorithms.community.label_propagation_communities(g))
     coms = [list(x) for x in coms]
 
-    return NodeClustering(coms, g, "Label Propagation", method_parameters={"":""})
+    return NodeClustering(coms, g_original, "Label Propagation", method_parameters={"":""})
 
 
-def async_fluid(g, k):
+def async_fluid(g_original, k):
     """
     Fluid Communities (FluidC) is based on the simple idea of fluids (i.e., communities) interacting in an environment (i.e., a non-complete graph), expanding and contracting.
     It is propagation-based algorithm and it allows to specify the number of desired communities (k) and it is asynchronous, where each vertex update is computed using the latest partial state of the graph.
 
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param k: Number of communities to search
     :return: EdgeClustering object
 
@@ -787,20 +787,20 @@ def async_fluid(g, k):
     Ferran Parés, Dario Garcia-Gasulla, Armand Vilalta, Jonatan Moreno, Eduard Ayguadé, Jesús Labarta, Ulises Cortés, Toyotaro Suzumura T. `Fluid Communities: A Competitive and Highly Scalable Community Detection Algorithm. <https://link.springer.com/chapter/10.1007/978-3-319-72150-7_19/>`_
     """
 
-    g = convert_graph_formats(g, nx.Graph)
+    g = convert_graph_formats(g_original, nx.Graph)
 
     coms = nx.algorithms.community.asyn_fluidc(g, k)
     coms = [list(x) for x in coms]
-    return NodeClustering(coms, g, "Fluid", method_parameters={"k": k})
+    return NodeClustering(coms, g_original, "Fluid", method_parameters={"k": k})
 
 
-def der(g, walk_len=3, threshold=.00001, iter_bound=50):
+def der(g_original, walk_len=3, threshold=.00001, iter_bound=50):
     """
     DER is a Diffusion Entropy Reducer graph clustering algorithm.
     The algorithm uses random walks to embed the graph in a space of measures, after which a modification of k-means in that space is applied. It creates the walks, creates an initialization, runs the algorithm,
     and finally extracts the communities.
 
-    :param graph: an undirected networkx graph object
+    :param g_original: an undirected networkx graph object
     :param walk_len: length of the random walk, default 3
     :param threshold: threshold for stop criteria; if the likelihood_diff is less than threshold tha algorithm stops, default 0.00001
     :param iter_bound: maximum number of iteration, default 50
@@ -822,7 +822,7 @@ def der(g, walk_len=3, threshold=.00001, iter_bound=50):
     .. note:: Reference implementation: https://github.com/komarkdev/der_graph_clustering
     """
 
-    graph = convert_graph_formats(g, nx.Graph)
+    graph = convert_graph_formats(g_original, nx.Graph)
 
     communities, _ = DER.der_graph_clustering(graph, walk_len=walk_len,
                                               alg_threshold=threshold, alg_iterbound=iter_bound)
@@ -832,18 +832,18 @@ def der(g, walk_len=3, threshold=.00001, iter_bound=50):
     for c in communities:
         coms.append([maps[n] for n in c])
 
-    return NodeClustering(coms, graph, "DER", method_parameters={"walk_len": walk_len, "threshold": threshold,
+    return NodeClustering(coms, g_original, "DER", method_parameters={"walk_len": walk_len, "threshold": threshold,
                                                                  "iter_bound": iter_bound})
 
 
-def frc_fgsn(g, theta, eps, r):
+def frc_fgsn(g_original, theta, eps, r):
     """Fuzzy-Rough Community Detection on Fuzzy Granular model of Social Network.
 
     FRC-FGSN assigns nodes to communities specifying the probability of each association.
     The flattened partition ensure that each node is associated to the community that maximize such association probability.
     FRC-FGSN may generate orphan nodes (i.e., nodes not assigned to any community).
 
-    :param graph: networkx/igraph object
+    :param g_original: networkx/igraph object
     :param theta: community density coefficient
     :param eps: coupling coefficient of the community. Ranges in [0, 1], small values ensure that only strongly connected node granules are merged togheter.
     :param r: radius of the granule (int)
@@ -865,7 +865,7 @@ def frc_fgsn(g, theta, eps, r):
     .. note:: Reference implementation: https://github.com/nidhisridhar/Fuzzy-Community-Detection
     """
 
-    graph = convert_graph_formats(g, nx.Graph)
+    graph = convert_graph_formats(g_original, nx.Graph)
     g, maps = nx_node_integer_mapping(graph)
 
     communities, fuzz_assoc = fuzzy_comm(graph, theta, eps, r)
@@ -880,17 +880,18 @@ def frc_fgsn(g, theta, eps, r):
     else:
         coms = [list(c) for c in communities]
 
-    return FuzzyNodeClustering(coms, fuzz_assoc, graph, "FuzzyComm", method_parameters={"theta": theta,
+    return FuzzyNodeClustering(coms, fuzz_assoc, g_original, "FuzzyComm", method_parameters={"theta": theta,
                                                                                         "eps": eps, "r": r})
 
 
-def sbm_dl(g, B_min=None,B_max=None, deg_corr=True, **kwargs):
+def sbm_dl(g_original, B_min=None,B_max=None, deg_corr=True, **kwargs):
     """Efficient Monte Carlo and greedy heuristic for the inference of stochastic block models.
 
     Fit a non-overlapping stochastic block model (SBM) by minimizing its description length using an agglomerative heuristic.
     If no parameter is given, the number of blocks will be discovered automatically. Bounds for the number of communities can
     be provided using B_min, B_max.
 
+    :param g_original: network/igraph object
     :param B_min: minimum number of communities that can be found
     :param B_max: maximum number of communities that can be found
     :param deg_corr: if true, use the degree corrected version of the SBM
@@ -915,7 +916,7 @@ def sbm_dl(g, B_min=None,B_max=None, deg_corr=True, **kwargs):
                         "The graph-tool library seems not to be installed (or incorrectly installed). \n"
                         "Please check installation procedure there https://git.skewed.de/count0/graph-tool/wikis/installation-instructions#native-installation \n"
                         "on linux/mac, you can use package managers to do so(apt-get install python3-graph-tool, brew install graph-tool, etc.)")
-    gt_g = convert_graph_formats(g, nx.Graph)
+    gt_g = convert_graph_formats(g_original, nx.Graph)
     gt_g, label_map = __from_nx_to_graph_tool(gt_g)
     state = gt.minimize_blockmodel_dl(gt_g, B_min, B_max, deg_corr=deg_corr)
 
@@ -923,10 +924,10 @@ def sbm_dl(g, B_min=None,B_max=None, deg_corr=True, **kwargs):
     affiliations = {label_map[i]: affiliations[i] for i in range(len(affiliations))}
     coms = affiliations2nodesets(affiliations)
     coms = [list(v) for k,v in coms.items()]
-    return NodeClustering(coms, g, "SBM", method_parameters={"B_min": B_min, "B_max": B_max, "deg_corr": deg_corr})
+    return NodeClustering(coms, g_original, "SBM", method_parameters={"B_min": B_min, "B_max": B_max, "deg_corr": deg_corr})
 
 
-def sbm_dl_nested(g, B_min=None,B_max=None, deg_corr=True, **kwargs):
+def sbm_dl_nested(g_original, B_min=None,B_max=None, deg_corr=True, **kwargs):
     """Efficient Monte Carlo and greedy heuristic for the inference of stochastic block models. (nested)
 
     Fit a nested non-overlapping stochastic block model (SBM) by minimizing its description length using an agglomerative heuristic.
@@ -934,6 +935,7 @@ def sbm_dl_nested(g, B_min=None,B_max=None, deg_corr=True, **kwargs):
     If no parameter is given, the number of blocks will be discovered automatically. Bounds for the number of communities can
     be provided using B_min, B_max.
 
+    :param g_original: igraph/networkx object
     :param B_min: minimum number of communities that can be found
     :param B_max: maximum number of communities that can be found
     :param deg_corr: if true, use the degree corrected version of the SBM
@@ -958,7 +960,7 @@ def sbm_dl_nested(g, B_min=None,B_max=None, deg_corr=True, **kwargs):
                         "The graph-tool library seems not to be installed (or incorrectly installed). \n"
                         "Please check installation procedure there https://git.skewed.de/count0/graph-tool/wikis/installation-instructions#native-installation \n"
                         "on linux/mac, you can use package managers to do so(apt-get install python3-graph-tool, brew install graph-tool, etc.)")
-    gt_g = convert_graph_formats(g, nx.Graph)
+    gt_g = convert_graph_formats(g_original, nx.Graph)
     gt_g, label_map = __from_nx_to_graph_tool(gt_g)
     state = gt.minimize_nested_blockmodel_dl(gt_g, B_min, B_max, deg_corr=deg_corr)
     level0 = state.get_levels()[0]
@@ -967,16 +969,16 @@ def sbm_dl_nested(g, B_min=None,B_max=None, deg_corr=True, **kwargs):
     affiliations = {label_map[i]: affiliations[i] for i in range(len(affiliations))}
     coms = affiliations2nodesets(affiliations)
     coms = [list(v) for k,v in coms.items()]
-    return NodeClustering(coms, g, "SBM_nested", method_parameters={"B_min": B_min, "B_max": B_max, "deg_corr": deg_corr})
+    return NodeClustering(coms, g_original, "SBM_nested", method_parameters={"B_min": B_min, "B_max": B_max, "deg_corr": deg_corr})
 
 
-def markov_clustering(g,  max_loop=1000):
+def markov_clustering(g_original,  max_loop=1000):
     """
     The Markov clustering algorithm (MCL) is based on simulation of (stochastic) flow in graphs.
     The MCL algorithm finds cluster structure in graphs by a mathematical bootstrapping procedure. The process deterministically computes (the probabilities of) random walks through the graph, and uses two operators transforming one set of probabilities into another. It does so using the language of stochastic matrices (also called Markov matrices) which capture the mathematical concept of random walks on a graph.
     The MCL algorithm simulates random walks within a graph by alternation of two operators called expansion and inflation.
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param max_loop: maximum number of iterations, default 1000
     :return: NodeClustering object
 
@@ -994,7 +996,7 @@ def markov_clustering(g,  max_loop=1000):
     .. note:: Reference implementation: https://github.com/HarshHarwani/markov-clustering-for-graphs
     """
 
-    g = convert_graph_formats(g, nx.Graph)
+    g = convert_graph_formats(g_original, nx.Graph)
     g, maps = nx_node_integer_mapping(g)
 
     communities = markov(g, max_loop)
@@ -1008,14 +1010,14 @@ def markov_clustering(g,  max_loop=1000):
     else:
         communities = [list(c) for c in communities]
 
-    return NodeClustering(communities, g, "Markov Clustering", method_parameters={"max_loop": max_loop})
+    return NodeClustering(communities, g_original, "Markov Clustering", method_parameters={"max_loop": max_loop})
 
 
-def edmot(g, component_count=2, cutoff=10):
+def edmot(g_original, component_count=2, cutoff=10):
     """
     The algorithm first creates the graph of higher order motifs. This graph is clustered by the Louvain method.
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param component_count: Number of extracted motif hypergraph components. Default is 2.
     :param cutoff: Motif edge cut-off value. Default is 10.
     :return: NodeClustering object
@@ -1034,7 +1036,7 @@ def edmot(g, component_count=2, cutoff=10):
     .. note:: Reference implementation: https://karateclub.readthedocs.io/
     """
 
-    g = convert_graph_formats(g, nx.Graph)
+    g = convert_graph_formats(g_original, nx.Graph)
     model = EdMot(component_count=2, cutoff=10)
 
     model.fit(g)
@@ -1047,4 +1049,4 @@ def edmot(g, component_count=2, cutoff=10):
 
     coms = [list(c) for c in coms_to_node.values()]
 
-    return NodeClustering(coms, g, "EdMot", method_parameters={"component_count": component_count, "cutoff": cutoff})
+    return NodeClustering(coms, g_original, "EdMot", method_parameters={"component_count": component_count, "cutoff": cutoff})

--- a/cdlib/algorithms/edge_clustering.py
+++ b/cdlib/algorithms/edge_clustering.py
@@ -7,13 +7,13 @@ from cdlib.algorithms.internal.HLC import HLC, HLC_read_edge_list_unweighted
 __all__ = ["hierarchical_link_community"]
 
 
-def hierarchical_link_community(g):
+def hierarchical_link_community(g_original):
     """
     HLC (hierarchical link clustering) is a method to classify links into topologically related groups.
     The algorithm uses a similarity between links to build a dendrogram where each leaf is a link from the original network and branches represent link communities.
     At each level of the link dendrogram is calculated the partition density function, based on link density inside communities, to pick the best level to cut.
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :return: EdgeClustering object
 
 
@@ -29,7 +29,7 @@ def hierarchical_link_community(g):
     Ahn, Yong-Yeol, James P. Bagrow, and Sune Lehmann. `Link communities reveal multiscale complexity in networks. <https://www.nature.com/articles/nature09182/>`_ nature 466.7307 (2010): 761.
     """
 
-    g = convert_graph_formats(g, nx.Graph)
+    g = convert_graph_formats(g_original, nx.Graph)
 
     adj, edges = HLC_read_edge_list_unweighted(g)
 
@@ -40,4 +40,4 @@ def hierarchical_link_community(g):
         coms[com].append(e)
 
     coms = [list(c) for c in coms.values()]
-    return EdgeClustering(coms, g, "HLC", method_parameters={})
+    return EdgeClustering(coms, g_original, "HLC", method_parameters={})

--- a/cdlib/algorithms/overlapping_partition.py
+++ b/cdlib/algorithms/overlapping_partition.py
@@ -30,11 +30,11 @@ __all__ = ["ego_networks", "demon", "angel", "node_perception", "overlapping_see
            "nmnf", "aslpaw", "percomvc"]
 
 
-def ego_networks(g, level=1):
+def ego_networks(g_original, level=1):
     """
     Ego-networks returns overlapping communities centered at each nodes within a given radius.
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param level: extrac communities with all neighbors of distance<=level from a node. Deafault 1
     :return: NodeClustering object
 
@@ -47,20 +47,20 @@ def ego_networks(g, level=1):
     >>> coms = algorithms.ego_networks(G)
     """
 
-    g = convert_graph_formats(g, nx.Graph)
+    g = convert_graph_formats(g_original, nx.Graph)
 
     coms = []
     for n in g.nodes():
         coms.append(list(nx.ego_graph(g, n, radius=level).nodes()))
-    return NodeClustering(coms, g, "Ego Network", method_parameters={"level": 1}, overlap=True)
+    return NodeClustering(coms, g_original, "Ego Network", method_parameters={"level": 1}, overlap=True)
 
 
-def demon(g, epsilon, min_com_size=3):
+def demon(g_original, epsilon, min_com_size=3):
     """
     Demon is a node-centric bottom-up overlapping community discovery algorithm.
     It leverages ego-network structures and overlapping label propagation to identify micro-scale communities that are subsequently merged in mesoscale ones.
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param epsilon: merging threshold in [0,1], default 0.25.
     :param min_com_size: minimum community size, default 3.
     :return: NodeClustering object
@@ -83,24 +83,24 @@ def demon(g, epsilon, min_com_size=3):
 
     """
 
-    g = convert_graph_formats(g, nx.Graph)
+    g = convert_graph_formats(g_original, nx.Graph)
 
     with suppress_stdout():
         dm = Demon(graph=g, epsilon=epsilon, min_community_size=min_com_size)
         coms = dm.execute()
         coms = [list(c) for c in coms]
 
-    return NodeClustering(coms, g, "DEMON", method_parameters={"epsilon": epsilon, "min_com_size": min_com_size},
+    return NodeClustering(coms, g_original, "DEMON", method_parameters={"epsilon": epsilon, "min_com_size": min_com_size},
                           overlap=True)
 
 
-def angel(g, threshold, min_community_size=3):
+def angel(g_original, threshold, min_community_size=3):
     """
     Angel is a node-centric bottom-up community discovery algorithm.
     It leverages ego-network structures and overlapping label propagation to identify micro-scale communities that are subsequently merged in mesoscale ones.
     Angel is the, faster, successor of Demon.
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param threshold: merging threshold in [0,1].
     :param min_community_size: minimum community size, default 3.
     :return: NodeClustering object
@@ -123,24 +123,24 @@ def angel(g, threshold, min_community_size=3):
     if Angel is None:
         raise ModuleNotFoundError("Optional dependency not satisfied: install angel-cd library to use the selected feature (likely pip install angel-cd). If using a notebook, you need also to restart your runtime/kernel.")
 
-    g = convert_graph_formats(g, ig.Graph)
+    g = convert_graph_formats(g_original, ig.Graph)
     with suppress_stdout():
         a = Angel(graph=g, min_comsize=min_community_size, threshold=threshold, save=False)
         coms = a.execute()
 
-    return NodeClustering(list(coms.values()), g, "ANGEL", method_parameters={"threshold": threshold,
+    return NodeClustering(list(coms.values()), g_original, "ANGEL", method_parameters={"threshold": threshold,
                                                                               "min_community_size": min_community_size},
                           overlap=True)
 
 
-def node_perception(g, threshold, overlap_threshold, min_comm_size=3):
+def node_perception(g_original, threshold, overlap_threshold, min_comm_size=3):
     """Node perception is based on the idea of joining together small sets of nodes.
     The algorithm first identifies sub-communities corresponding to each node’s perception of the network around it.
     To perform this step, it considers each node individually, and partition that node’s neighbors into communities using some existing community detection method.
     Next, it creates a new network in which every node corresponds to a sub-community, and two nodes are linked if their associated sub-communities overlap by at least some threshold amount.
     Finally, the algorithm identifies overlapping communities in this new network, and for every such community, merge together the associated sub-communities to identify communities in the original network.
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param threshold: the tolerance required in order to merge communities
     :param overlap_threshold: the overlap tolerance
     :param min_comm_size: minimum community size default 3
@@ -158,7 +158,7 @@ def node_perception(g, threshold, overlap_threshold, min_comm_size=3):
     Sucheta Soundarajan and John E. Hopcroft. 2015. `Use of Local Group Information to Identify Communities in Networks. <https://dl.acm.org/citation.cfm?id=2737800.2700404/>`_ ACM Trans. Knowl. Discov. Data 9, 3, Article 21 (April 2015), 27 pages. DOI=http://dx.doi.org/10.1145/2700404
 
     """
-    g = convert_graph_formats(g, nx.Graph)
+    g = convert_graph_formats(g_original, nx.Graph)
     tp = type(list(g.nodes())[0])
 
     with suppress_stdout():
@@ -172,19 +172,19 @@ def node_perception(g, threshold, overlap_threshold, min_comm_size=3):
                 communities.append(c)
             coms = communities
 
-    return NodeClustering(coms, g, "Node Perception", method_parameters={"threshold": threshold,
+    return NodeClustering(coms, g_original, "Node Perception", method_parameters={"threshold": threshold,
                                                                          "overlap_threshold": overlap_threshold,
                                                                          "min_com_size": min_comm_size},
                           overlap=True)
 
 
-def overlapping_seed_set_expansion(g, seeds, ninf=False, expansion='ppr', stopping='cond', nworkers=1,
+def overlapping_seed_set_expansion(g_original, seeds, ninf=False, expansion='ppr', stopping='cond', nworkers=1,
                                    nruns=13, alpha=0.99, maxexpand=float('INF'), delta=0.2):
     """
     OSSE is an overlapping community detection algorithm optimizing the conductance community score
     The algorithm uses a seed set expansion approach; the key idea is to find good seeds, and then expand these seed sets using the personalized PageRank clustering procedure.
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param seeds: Node list
     :param ninf: Neighbourhood Inflation parameter (boolean)
     :param expansion: Seed expansion: ppr or vppr
@@ -211,7 +211,7 @@ def overlapping_seed_set_expansion(g, seeds, ninf=False, expansion='ppr', stoppi
     .. note:: Reference implementation: https://github.com/pratham16/algorithms-detection-by-seed-expansion
     """
 
-    g = convert_graph_formats(g, nx.Graph)
+    g = convert_graph_formats(g_original, nx.Graph)
 
     g, maps = nx_node_integer_mapping(g)
     if maps is not None:
@@ -233,7 +233,7 @@ def overlapping_seed_set_expansion(g, seeds, ninf=False, expansion='ppr', stoppi
     else:
         coms = communities
 
-    return NodeClustering(coms, g, "Overlapping SSE", method_parameters={"seeds": seeds, "ninf": ninf,
+    return NodeClustering(coms, g_original, "Overlapping SSE", method_parameters={"seeds": seeds, "ninf": ninf,
                                                                          "expansion": expansion,
                                                                          "stopping": stopping,
                                                                          "nworkers": nworkers,
@@ -243,12 +243,12 @@ def overlapping_seed_set_expansion(g, seeds, ninf=False, expansion='ppr', stoppi
                           overlap=True)
 
 
-def kclique(g, k):
+def kclique(g_original, k):
     """
     Find k-clique communities in graph using the percolation method.
     A k-clique community is the union of all cliques of size k that can be reached through adjacent (sharing k-1 nodes) k-cliques.
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param k: Size of smallest clique
     :return: NodeClustering object
 
@@ -268,14 +268,14 @@ def kclique(g, k):
 
     coms = list(nx.algorithms.community.k_clique_communities(g, k))
     coms = [list(x) for x in coms]
-    return NodeClustering(coms, g, "Klique", method_parameters={"k": k}, overlap=True)
+    return NodeClustering(coms, g_original, "Klique", method_parameters={"k": k}, overlap=True)
 
 
-def lfm(g, alpha):
+def lfm(g_original, alpha):
     """LFM is based on the local optimization of a fitness function.
     It finds both overlapping communities and the hierarchical structure.
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param alpha: parameter to controll the size of the communities:  Large values of alpha yield very small communities, small values instead deliver large modules. If alpha is small enough, all nodes end up in the same cluster, the network itself. In most cases, for alpha < 0.5 there is only one community, for alpha > 2 one recovers the smallest communities. A natural choise is alpha =1.
     :return: NodeClustering object
 
@@ -291,21 +291,21 @@ def lfm(g, alpha):
     Lancichinetti, Andrea, Santo Fortunato, and János Kertész. `Detecting the overlapping and hierarchical community structure in complex networks <https://arxiv.org/abs/0802.1218/>`_ New Journal of Physics 11.3 (2009): 033015.
     """
 
-    g = convert_graph_formats(g, nx.Graph)
+    g = convert_graph_formats(g_original, nx.Graph)
 
     algorithm = LFM_nx(g, alpha)
     coms = algorithm.execute()
 
-    return NodeClustering(coms, g, "LFM", method_parameters={"alpha": alpha}, overlap=True)
+    return NodeClustering(coms, g_original, "LFM", method_parameters={"alpha": alpha}, overlap=True)
 
 
-def lais2(g):
+def lais2(g_original):
     """
     LAIS2 is an overlapping community discovery algorithm based on the density function.
     In the algorithm considers the density of a group is defined as the average density of the communication exchanges between the actors of the group.
     LAIS2 IS composed of two procedures LA (Link Aggregate Algorithm) and IS2 (Iterative Scan Algorithm).
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :return: NodeClustering object
 
 
@@ -324,13 +324,13 @@ def lais2(g):
 
     """
 
-    g = convert_graph_formats(g, nx.Graph)
+    g = convert_graph_formats(g_original, nx.Graph)
 
     coms = LAIS2(g)
-    return NodeClustering(coms, g, "LAIS2", method_parameters={"":""}, overlap=True)
+    return NodeClustering(coms, g_original, "LAIS2", method_parameters={"":""}, overlap=True)
 
 
-def congo(g, number_communities, height=2):
+def congo(g_original, number_communities, height=2):
     """
     CONGO (CONGA Optimized) is an optimization of the CONGA algortithm.
     The CONGO algorithm is the same as CONGA but using local betweenness. The complete CONGO algorithm is as follows:
@@ -343,7 +343,7 @@ def congo(g, number_communities, height=2):
         c) Add betweenness for the same region.
     4. Repeat from step 2 until no edges remain.
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param number_communities: the number of communities desired
     :param height: The lengh of the longest shortest paths that CONGO considers, default 2
     :return: NodeClustering object
@@ -366,7 +366,7 @@ def congo(g, number_communities, height=2):
     if ig is None:
         raise ModuleNotFoundError("Optional dependency not satisfied: install igraph to use the selected feature.")
 
-    g = convert_graph_formats(g, ig.Graph)
+    g = convert_graph_formats(g_original, ig.Graph)
 
     communities = Congo_(g, number_communities, height)
 
@@ -374,11 +374,11 @@ def congo(g, number_communities, height=2):
     for c in communities:
         coms.append([g.vs[x]['name'] for x in c])
 
-    return NodeClustering(coms, g, "Congo", method_parameters={"number_communities": number_communities,
+    return NodeClustering(coms, g_original, "Congo", method_parameters={"number_communities": number_communities,
                                                                "height": height}, overlap=True)
 
 
-def conga(g, number_communities):
+def conga(g_original, number_communities):
     """
     CONGA (Cluster-Overlap Newman Girvan Algorithm) is an algorithm for discovering overlapping communities.
     It extends the  Girvan and Newman’s algorithm with a specific method of deciding when and how to split vertices. The algorithm is as follows:
@@ -391,7 +391,7 @@ def conga(g, number_communities):
     6. Recalculate edge betweenness for all remaining edges in same component(s) as removed edge or split vertex.
     7. Repeat from step 2 until no edges remain.
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param number_communities: the number of communities desired
     :return: NodeClustering object
 
@@ -412,23 +412,23 @@ def conga(g, number_communities):
     if ig is None:
         raise ModuleNotFoundError("Optional dependency not satisfied: install igraph to use the selected feature.")
 
-    g = convert_graph_formats(g, ig.Graph)
+    g = convert_graph_formats(g_original, ig.Graph)
 
     communities = Conga_(g, number_communities=3)
     coms = []
     for c in communities:
         coms.append([g.vs[x]['name'] for x in c])
 
-    return NodeClustering(coms, g, "Conga", method_parameters={"number_communities": number_communities}, overlap=True)
+    return NodeClustering(coms, g_original, "Conga", method_parameters={"number_communities": number_communities}, overlap=True)
 
 
-def lemon(graph, seeds, min_com_size=20, max_com_size=50, expand_step=6, subspace_dim=3, walk_steps=3, biased=False):
+def lemon(g_original, seeds, min_com_size=20, max_com_size=50, expand_step=6, subspace_dim=3, walk_steps=3, biased=False):
     """Lemon is a large scale overlapping community detection method based on local expansion via minimum one norm.
 
     The algorithm adopts a local expansion method in order to identify the community members from a few exemplary seed members.
     The algorithm finds the community by seeking a sparse vector in the span of the local spectra such that the seeds are in its support. LEMON can achieve the highest detection accuracy among state-of-the-art proposals. The running time depends on the size of the community rather than that of the entire graph.
 
-    :param graph: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param seeds: Node list
     :param min_com_size: the minimum size of a single community in the network, default 20
     :param max_com_size: the maximum size of a single community in the network, default 50
@@ -453,7 +453,7 @@ def lemon(graph, seeds, min_com_size=20, max_com_size=50, expand_step=6, subspac
     .. note:: Reference implementation: https://github.com/YixuanLi/LEMON
     """
 
-    graph = convert_graph_formats(graph, nx.Graph)
+    graph = convert_graph_formats(g_original, nx.Graph)
     graph_m = nx.convert_matrix.to_numpy_array(graph)
 
     node_to_pos = {n: p for p, n in enumerate(graph.nodes())}
@@ -464,14 +464,14 @@ def lemon(graph, seeds, min_com_size=20, max_com_size=50, expand_step=6, subspac
     community = LEMON.lemon(graph_m, seeds, min_com_size, max_com_size, expand_step,
                             subspace_dim=subspace_dim, walk_steps=walk_steps, biased=biased)
 
-    return NodeClustering([[pos_to_node[n] for n in community]], graph,
+    return NodeClustering([[pos_to_node[n] for n in community]], g_original,
                           "LEMON", method_parameters=dict(seeds=str(list(seeds)), min_com_size=min_com_size,
                                                           max_com_size=max_com_size, expand_step=expand_step,
                                                           subspace_dim=subspace_dim, walk_steps=walk_steps,
                                                           biased=biased), overlap=True)
 
 
-def slpa(g, t=21, r=0.1):
+def slpa(g_original, t=21, r=0.1):
     """
     SLPA is an overlapping community discovery that extends tha LPA.
     SLPA consists of the following three stages:
@@ -480,7 +480,7 @@ def slpa(g, t=21, r=0.1):
     3) the post-processing
 
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param t: maximum number of iterations, default 20
     :param r: threshold  ∈ [0, 1]. It is used in the post-processing stage: if the probability of seeing a particular label during the whole process is less than r, this label is deleted from a node’s memory. Default 0.1
     :return: EdgeClustering object
@@ -502,18 +502,18 @@ def slpa(g, t=21, r=0.1):
     .. note:: Reference implementation: https://github.com/kbalasu/SLPA
     """
 
-    g = convert_graph_formats(g, nx.Graph)
+    g = convert_graph_formats(g_original, nx.Graph)
 
     coms = slpa_nx(g, T=t, r=r)
-    return NodeClustering(coms, g, "SLPA", method_parameters={"T": t, "r": r}, overlap=True)
+    return NodeClustering(coms, g_original, "SLPA", method_parameters={"T": t, "r": r}, overlap=True)
 
 
-def multicom(g, seed_node):
+def multicom(g_original, seed_node):
     """
     MULTICOM is an algorithm for detecting multiple local communities, possibly overlapping, by expanding the initial seed set.
     This algorithm uses local scoring metrics to define an embedding of the graph around the seed set. Based on this embedding, it picks new seeds in the neighborhood of the original seed set, and uses these new seeds to recover multiple communities.
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param seed_node: Id of the seed node around which we want to detect communities.
     :return: EdgeClustering object
 
@@ -533,7 +533,7 @@ def multicom(g, seed_node):
 
     """
 
-    g = convert_graph_formats(g, nx.Graph)
+    g = convert_graph_formats(g_original, nx.Graph)
     g, maps = nx_node_integer_mapping(g)
 
     mc = MultiCom(g)
@@ -547,15 +547,15 @@ def multicom(g, seed_node):
     else:
         communities = [list(c) for c in coms]
 
-    return NodeClustering(communities, g, "Multicom", method_parameters={"seeds": seed_node}, overlap=True)
+    return NodeClustering(communities, g_original, "Multicom", method_parameters={"seeds": seed_node}, overlap=True)
 
 
-def big_clam(g, dimensions=8, iterations=50, learning_rate=0.005):
+def big_clam(g_original, dimensions=8, iterations=50, learning_rate=0.005):
     """
     BigClam is an overlapping community detection method that scales to large networks.
     The procedure uses gradient ascent to create an embedding which is used for deciding the node-cluster affiliations.
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param dimensions: Number of embedding dimensions. Default 8.
     :param iterations: Number of training iterations. Default 50.
     :param learning_rate: Gradient ascent learning rate. Default is 0.005.
@@ -576,7 +576,7 @@ def big_clam(g, dimensions=8, iterations=50, learning_rate=0.005):
     .. note:: Reference implementation: https://karateclub.readthedocs.io/
     """
 
-    g = convert_graph_formats(g, nx.Graph)
+    g = convert_graph_formats(g_original, nx.Graph)
 
     model = BigClam(dimensions=dimensions, iterations=iterations, learning_rate=learning_rate)
     model.fit(g)
@@ -589,15 +589,15 @@ def big_clam(g, dimensions=8, iterations=50, learning_rate=0.005):
 
     coms = [list(c) for c in coms_to_node.values()]
 
-    return NodeClustering(coms, g, "BigClam", method_parameters={"dimensions": dimensions, "iterations": iterations,
+    return NodeClustering(coms, g_original, "BigClam", method_parameters={"dimensions": dimensions, "iterations": iterations,
                                                                  "learning_rate": learning_rate}, overlap=True)
 
 
-def danmf(g, layers=(32, 8), pre_iterations=100, iterations=100, seed=42, lamb=0.01):
+def danmf(g_original, layers=(32, 8), pre_iterations=100, iterations=100, seed=42, lamb=0.01):
     """
     The procedure uses telescopic non-negative matrix factorization in order to learn a cluster memmbership distribution over nodes. The method can be used in an overlapping and non-overlapping way.
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param layers: Autoencoder layer sizes in a list of integers. Default [32, 8].
     :param pre_iterations: Number of pre-training epochs. Default 100.
     :param iterations: Number of training epochs. Default 100.
@@ -619,7 +619,7 @@ def danmf(g, layers=(32, 8), pre_iterations=100, iterations=100, seed=42, lamb=0
 
     .. note:: Reference implementation: https://karateclub.readthedocs.io/
     """
-    g = convert_graph_formats(g, nx.Graph)
+    g = convert_graph_formats(g_original, nx.Graph)
     model = DANMF(layers, pre_iterations, iterations, seed, lamb)
     model.fit(g)
     members = model.get_memberships()
@@ -631,16 +631,16 @@ def danmf(g, layers=(32, 8), pre_iterations=100, iterations=100, seed=42, lamb=0
 
     coms = [list(c) for c in coms_to_node.values()]
 
-    return NodeClustering(coms, g, "DANMF", method_parameters={"layers": layers, "pre_iteration": pre_iterations,
+    return NodeClustering(coms, g_original, "DANMF", method_parameters={"layers": layers, "pre_iteration": pre_iterations,
                                                                "iterations": iterations, "seed": seed, "lamb": lamb},
                           overlap=True)
 
 
-def egonet_splitter(g, resolution=1.0):
+def egonet_splitter(g_original, resolution=1.0):
     """
     The method first creates the egonets of nodes. A persona-graph is created which is clustered by the Louvain method.
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param resolution: Resolution parameter of Python Louvain. Default 1.0.
     :return: NodeClustering object
 
@@ -658,7 +658,7 @@ def egonet_splitter(g, resolution=1.0):
 
     .. note:: Reference implementation: https://karateclub.readthedocs.io/
     """
-    g = convert_graph_formats(g, nx.Graph)
+    g = convert_graph_formats(g_original, nx.Graph)
     model = EgoNetSplitter(resolution=resolution)
     model.fit(g)
     members = model.get_memberships()
@@ -671,14 +671,14 @@ def egonet_splitter(g, resolution=1.0):
 
     coms = [list(c) for c in coms_to_node.values()]
 
-    return NodeClustering(coms, g, "EgoNetSplitter", method_parameters={"resolution":resolution}, overlap=True)
+    return NodeClustering(coms, g_original, "EgoNetSplitter", method_parameters={"resolution":resolution}, overlap=True)
 
 
-def nnsed(g, dimensions=32, iterations=10, seed=42):
+def nnsed(g_original, dimensions=32, iterations=10, seed=42):
     """
     The procedure uses non-negative matrix factorization in order to learn an unnormalized cluster membership distribution over nodes. The method can be used in an overlapping and non-overlapping way.
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param dimensions: Embedding layer size. Default is 32.
     :param iterations: Number of training epochs. Default 10.
     :param seed:  Random seed for weight initializations. Default 42.
@@ -698,7 +698,7 @@ def nnsed(g, dimensions=32, iterations=10, seed=42):
 
     .. note:: Reference implementation: https://karateclub.readthedocs.io/
     """
-    g = convert_graph_formats(g, nx.Graph)
+    g = convert_graph_formats(g_original, nx.Graph)
     model = NNSED(dimensions=dimensions,iterations=iterations, seed=seed)
     model.fit(g)
     members = model.get_memberships()
@@ -710,15 +710,15 @@ def nnsed(g, dimensions=32, iterations=10, seed=42):
 
     coms = [list(c) for c in coms_to_node.values()]
 
-    return NodeClustering(coms, g, "NNSED", method_parameters={"dimension": dimensions, "iterations": iterations,
+    return NodeClustering(coms, g_original, "NNSED", method_parameters={"dimension": dimensions, "iterations": iterations,
                                                                "seed": seed}, overlap=True)
 
 
-def nmnf(g, dimensions=128, clusters=10, lambd=0.2, alpha=0.05, beta=0.05, iterations=200, lower_control=1e-15, eta=5.0):
+def nmnf(g_original, dimensions=128, clusters=10, lambd=0.2, alpha=0.05, beta=0.05, iterations=200, lower_control=1e-15, eta=5.0):
     """
     The procedure uses joint non-negative matrix factorization with modularity based regul;arization in order to learn a cluster memmbership distribution over nodes. The method can be used in an overlapping and non-overlapping way.
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :param dimensions: Number of dimensions. Default is 128.
     :param clusters: Number of clusters. Default is 10.
     :param lambd: KKT penalty. Default is 0.2
@@ -743,7 +743,7 @@ def nmnf(g, dimensions=128, clusters=10, lambd=0.2, alpha=0.05, beta=0.05, itera
 
     .. note:: Reference implementation: https://karateclub.readthedocs.io/
     """
-    g = convert_graph_formats(g, nx.Graph)
+    g = convert_graph_formats(g_original, nx.Graph)
     model = MNMF(dimensions=dimensions, clusters=clusters, lambd=lambd, alpha=alpha, beta=beta, iterations=iterations,
                  lower_control=lower_control, eta=eta)
     model.fit(g)
@@ -756,18 +756,18 @@ def nmnf(g, dimensions=128, clusters=10, lambd=0.2, alpha=0.05, beta=0.05, itera
 
     coms = [list(c) for c in coms_to_node.values()]
 
-    return NodeClustering(coms, g, "MNMF", method_parameters={"dimension": dimensions, "clusters": clusters,
+    return NodeClustering(coms, g_original, "MNMF", method_parameters={"dimension": dimensions, "clusters": clusters,
                                                               "lambd": lambd, "alpha": alpha, "beta": beta,
                                                               "iterations": iterations, "lower_control": lower_control,
                                                               "eta": eta}, overlap=True)
 
 
-def aslpaw(g):
+def aslpaw(g_original):
     """
     ASLPAw can be used for disjoint and overlapping community detection and works on weighted/unweighted and directed/undirected networks.
     ASLPAw is adaptive with virtually no configuration parameters.
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :return: NodeClustering object
 
 
@@ -784,7 +784,7 @@ def aslpaw(g):
 
     .. note:: Reference implementation: https://github.com/fsssosei/ASLPAw
     """
-    g = convert_graph_formats(g, nx.Graph)
+    g = convert_graph_formats(g_original, nx.Graph)
     coms = ASLPAw(g).adj
 
     communities = defaultdict(list)
@@ -793,16 +793,16 @@ def aslpaw(g):
             for cid in c:
                 communities[cid].append(i)
 
-    return NodeClustering(communities.values(), g, "ASLPAw", method_parameters={}, overlap=True)
+    return NodeClustering(communities.values(), g_original, "ASLPAw", method_parameters={}, overlap=True)
 
 
-def percomvc(g):
+def percomvc(g_original):
     """
     The PercoMVC approach composes of two steps.
     In the first step, the algorithm attempts to determine all communities that the clique percolation algorithm may find.
     In the second step, the algorithm computes the Eigenvector Centrality method on the output of the first step to measure the influence of network nodes and reduce the rate of the unclassified nodes
 
-    :param g: a networkx/igraph object
+    :param g_original: a networkx/igraph object
     :return: NodeClustering object
 
 
@@ -819,7 +819,7 @@ def percomvc(g):
 
     .. note:: Reference implementation: https://github.com/sedjokas/PercoMCV-Code-source
     """
-    g = convert_graph_formats(g, nx.Graph)
+    g = convert_graph_formats(g_original, nx.Graph)
     communities = percoMVC(g)
 
-    return NodeClustering(communities, g, "PercoMVC", method_parameters={}, overlap=True)
+    return NodeClustering(communities, g_original, "PercoMVC", method_parameters={}, overlap=True)

--- a/cdlib/algorithms/overlapping_partition.py
+++ b/cdlib/algorithms/overlapping_partition.py
@@ -264,7 +264,7 @@ def kclique(g_original, k):
     Gergely Palla, Imre Derényi, Illés Farkas1, and Tamás Vicsek, `Uncovering the overlapping community structure of complex networks in nature and society <https://www.nature.com/articles/nature03607/>`_ Nature 435, 814-818, 2005, doi:10.1038/nature03607
     """
 
-    g = convert_graph_formats(g, nx.Graph)
+    g = convert_graph_formats(g_original, nx.Graph)
 
     coms = list(nx.algorithms.community.k_clique_communities(g, k))
     coms = [list(x) for x in coms]
@@ -793,7 +793,7 @@ def aslpaw(g_original):
             for cid in c:
                 communities[cid].append(i)
 
-    return NodeClustering(communities.values(), g_original, "ASLPAw", method_parameters={}, overlap=True)
+    return NodeClustering(list(communities.values()), g_original, "ASLPAw", method_parameters={}, overlap=True)
 
 
 def percomvc(g_original):

--- a/cdlib/classes/clustering.py
+++ b/cdlib/classes/clustering.py
@@ -3,6 +3,20 @@ import json
 
 class Clustering(object):
 
+    def __convert_back_to_original_nodes_names_if_needed(self,communities):
+        """
+        If original nodes are int and we converted the graph to igraph, they were transformed to int. So we need to
+        transform them back to int
+        :return:
+        """
+        if len(communities)>0 and type(communities[0][0]) is str:
+            if communities[0][0][:1]=="\\":
+                to_return = []
+                for com in communities:
+                    to_return.append([int(x[1:]) for x in com])
+                return to_return
+        return communities
+
     def __init__(self, communities, graph, method_name, method_parameters=None, overlap=False):
         """
         Communities representation.
@@ -11,12 +25,15 @@ class Clustering(object):
         :param method_name: algorithms discovery algorithm name
         :param overlap: boolean, whether the partition is overlapping or not
         """
+        communities = self.__convert_back_to_original_nodes_names_if_needed(communities)
         self.communities = sorted(communities, key=len, reverse=True)
         self.graph = graph
         self.method_name = method_name
         self.overlap = overlap
         self.method_parameters = method_parameters
         self.node_coverage = 1
+
+
 
     def to_json(self):
         """

--- a/cdlib/classes/node_clustering.py
+++ b/cdlib/classes/node_clustering.py
@@ -23,6 +23,7 @@ class NodeClustering(Clustering):
     def __init__(self, communities, graph, method_name, method_parameters=None, overlap=False):
         super().__init__(communities, graph, method_name, method_parameters, overlap)
 
+
         if graph is not None:
             node_count = len({nid: None for community in communities for nid in community})
             if isinstance(graph, nx.Graph):
@@ -34,6 +35,9 @@ class NodeClustering(Clustering):
 
     def __check_graph(self):
         return self.graph is not None
+
+
+
 
     def to_node_community_map(self):
         """

--- a/cdlib/utils.py
+++ b/cdlib/utils.py
@@ -32,13 +32,16 @@ def suppress_stdout():
             sys.stderr = old_stderr
 
 
-def __from_nx_to_graph_tool(g, directed=False):
+def __from_nx_to_graph_tool(g, directed=None):
     """
 
     :param g:
     :param directed:
     :return:
     """
+
+    if directed is None:
+        directed = g.is_directed()
 
     if gt is None:
         raise ModuleNotFoundError(
@@ -54,7 +57,11 @@ def __from_nx_to_graph_tool(g, directed=False):
     return gt_g, {v: k for k, v in node_map.items()}
 
 
-def __from_graph_tool_to_nx(graph, node_map=None, directed=False):
+def __from_graph_tool_to_nx(graph, node_map=None, directed=None):
+
+    if directed is None:
+        directed = graph.is_directed()
+
     if directed:
         tp = nx.DiGraph()
     else:
@@ -161,7 +168,7 @@ def __from_igraph_to_nx(ig, directed=None):
     return tp
 
 
-def convert_graph_formats(graph, desired_format, directed=False):
+def convert_graph_formats(graph, desired_format, directed=None):
     """Converts from/to networkx/igraph
 
 


### PR DESCRIPTION
1)In all functions, return the original graph instead of the converted one
2)If conversion to igraph and nodes are int, store in the "name" attribute a string version with a code ("!!") and convert it back to int when creating the clustering object
3)By default, we now keep if the graph is directed or not when converting. Some methods now fail, more or less gracefully.