### PR TITLE
:art: Add support for colormap and community filtering

### DIFF
--- a/cdlib/viz/networks.py
+++ b/cdlib/viz/networks.py
@@ -1,3 +1,6 @@
+import warnings
+import numpy as np
+import matplotlib
 import matplotlib.pyplot as plt
 import networkx as nx
 from cdlib import NodeClustering
@@ -6,12 +9,35 @@ from community import induced_graph
 
 __all__ = ["plot_network_clusters", "plot_community_graph"]
 
-COLOR = ['r', 'b', 'g', 'c', 'm', 'y', 'k',
-         '0.8', '0.2', '0.6', '0.4', '0.7', '0.3', '0.9', '0.1', '0.5']
+# [r, b, g, c, m, y, k, 0.8, 0.2, 0.6, 0.4, 0.7, 0.3, 0.9, 0.1, 0.5]
+COLOR = (
+    (1, 0, 0),
+    (0, 0, 1),
+    (0, 0.5, 0),
+    (0, 0.75, 0.75),
+    (0.75, 0, 0.75),
+    (0.75, 0.75, 0),
+    (0, 0, 0),
+    (0.8, 0.8, 0.8),
+    (0.2, 0.2, 0.2),
+    (0.6, 0.6, 0.6),
+    (0.4, 0.4, 0.4),
+    (0.7, 0.7, 0.7),
+    (0.3, 0.3, 0.3),
+    (0.9, 0.9, 0.9),
+    (0.1, 0.1, 0.1),
+    (0.5, 0.5, 0.5)
+)
 
+def __filter(partition, top_k, min_size):
+    if isinstance(min_size, int) and min_size > 0:
+        partition = list(filter(lambda nodes: len(nodes) >= min_size, partition))
+    if isinstance(top_k, int) and top_k > 0:
+        partition = partition[:top_k]
+    return partition
 
 def plot_network_clusters(graph, partition, position=None, figsize=(8, 8), node_size=200, plot_overlaps=False,
-                          plot_labels=False):
+                          plot_labels=False, cmap=None, top_k=None, min_size=None):
     """
     Plot a graph with node color coding for communities.
 
@@ -22,6 +48,9 @@ def plot_network_clusters(graph, partition, position=None, figsize=(8, 8), node_
     :param node_size: int, default 200
     :param plot_overlaps: bool, default False. Flag to control if multiple algorithms memberships are plotted.
     :param plot_labels: bool, default False. Flag to control if node labels are plotted.
+    :param cmap: str or Matplotlib colormap, Colormap(Matplotlib colormap) for mapping intensities of nodes. If set to None, original colormap is used.
+    :param top_k: int, Show the top K influential communities. If set to zero or negative value indicates all.
+    :param min_size: int, Exclude communities below the specified minimum size.
 
     Example:
 
@@ -32,18 +61,41 @@ def plot_network_clusters(graph, partition, position=None, figsize=(8, 8), node_
     >>> pos = nx.spring_layout(g)
     >>> viz.plot_network_clusters(g, coms, pos)
     """                  
-    partition = partition.communities
+    if not isinstance(cmap, (type(None), str, matplotlib.colors.Colormap)):
+        raise TypeError("The 'cmap' argument must be NoneType, str or matplotlib.colors.Colormap, "
+                        "not %s." % (type(cmap).__name__))
+
+    partition = __filter(partition.communities, top_k, min_size)
     graph = convert_graph_formats(graph, nx.Graph)
     if position==None:
         position=nx.spring_layout(graph)
 
-    n_communities = min(len(partition), len(COLOR))
+    n_communities = len(partition)
+    if n_communities == 0:
+        warnings.warn("There are no communities that match the filter criteria.")
+        return None
+
+    if cmap is None:
+        n_communities = min(n_communities, len(COLOR))
+        cmap = matplotlib.colors.ListedColormap(COLOR[:n_communities])
+    else:
+        cmap = plt.cm.get_cmap(cmap, n_communities)
+    _norm = matplotlib.colors.Normalize(vmin=0, vmax=n_communities-1)
+    fontcolors = list(map(lambda rgb: ".15" if np.dot(rgb, [0.2126, 0.7152, 0.0722]) > .408 else "w",
+                          [cmap(_norm(i))[:3] for i in range(n_communities)]))
+
     plt.figure(figsize=figsize)
     plt.axis('off')
 
-    fig = nx.draw_networkx_nodes(graph, position, node_size=node_size, node_color='w')
+    filtered_nodelist = list(np.concatenate(partition))
+    filtered_edgelist = list(filter(lambda edge: len(np.intersect1d(edge, filtered_nodelist))==2, graph.edges()))
+    fig = nx.draw_networkx_nodes(graph, position, node_size=node_size, node_color='w',
+                                 nodelist=filtered_nodelist)
     fig.set_edgecolor('k')
-    nx.draw_networkx_edges(graph, position, alpha=.5)
+    nx.draw_networkx_edges(graph, position, alpha=.5, edgelist=filtered_edgelist)
+    if plot_labels:
+        nx.draw_networkx_labels(graph, position, font_color=".2",
+                                labels={node: str(node) for node in filtered_nodelist})
     for i in range(n_communities):
         if len(partition[i]) > 0:
             if plot_overlaps:
@@ -51,35 +103,41 @@ def plot_network_clusters(graph, partition, position=None, figsize=(8, 8), node_
             else:
                 size = node_size
             fig = nx.draw_networkx_nodes(graph, position, node_size=size,
-                                         nodelist=partition[i], node_color=COLOR[i])
+                                         nodelist=partition[i], node_color=[cmap(_norm(i))])
             fig.set_edgecolor('k')
     if plot_labels:
-        nx.draw_networkx_labels(graph, position, labels={node: str(node) for node in graph.nodes()})
+        for i in range(n_communities):
+            if len(partition[i]) > 0:
+                nx.draw_networkx_labels(graph, position, font_color=fontcolors[i],
+                                        labels={node: str(node) for node in partition[i]})
 
     return fig
 
 
-def plot_community_graph(graph, partition, figsize=(8, 8), node_size=200, plot_overlaps=False, plot_labels=False):
+def plot_community_graph(graph, partition, figsize=(8, 8), node_size=200, plot_overlaps=False, plot_labels=False, cmap=None, top_k=None, min_size=None):
     """
-        Plot a algorithms-graph with node color coding for communities.
+    Plot a algorithms-graph with node color coding for communities.
 
-        :param graph: NetworkX/igraph graph
-        :param partition: NodeClustering object
-        :param figsize: the figure size; it is a pair of float, default (8, 8)
-        :param node_size: int, default 200
-        :param plot_overlaps: bool, default False. Flag to control if multiple algorithms memberships are plotted.
-        :param plot_labels: bool, default False. Flag to control if node labels are plotted.
+    :param graph: NetworkX/igraph graph
+    :param partition: NodeClustering object
+    :param figsize: the figure size; it is a pair of float, default (8, 8)
+    :param node_size: int, default 200
+    :param plot_overlaps: bool, default False. Flag to control if multiple algorithms memberships are plotted.
+    :param plot_labels: bool, default False. Flag to control if node labels are plotted.
+    :param cmap: str or Matplotlib colormap, Colormap(Matplotlib colormap) for mapping intensities of nodes. If set to None, original colormap is used..
+    :param top_k: int, Show the top K influential communities. If set to zero or negative value indicates all.
+    :param min_size: int, Exclude communities below the specified minimum size.
 
-        Example:
+    Example:
 
-        >>> from cdlib import algorithms, viz
-        >>> import networkx as nx
-        >>> g = nx.karate_club_graph()
-        >>> coms = algorithms.louvain(g)
-        >>> viz.plot_community_graph(g, coms)
-        """
+    >>> from cdlib import algorithms, viz
+    >>> import networkx as nx
+    >>> g = nx.karate_club_graph()
+    >>> coms = algorithms.louvain(g)
+    >>> viz.plot_community_graph(g, coms)
+    """
 
-    cms = partition.communities
+    cms = __filter(partition.communities, top_k, min_size)
 
     node_to_com = {}
     for cid, com in enumerate(cms):
@@ -101,7 +159,7 @@ def plot_community_graph(graph, partition, figsize=(8, 8), node_size=200, plot_o
     node_cms = [[node] for node in c_graph.nodes()]
 
     return plot_network_clusters(c_graph, NodeClustering(node_cms, None, ""), nx.spring_layout(c_graph), figsize=figsize,
-                                 node_size=node_size, plot_overlaps=plot_overlaps, plot_labels=plot_labels)
+                                 node_size=node_size, plot_overlaps=plot_overlaps, plot_labels=plot_labels, cmap=cmap)
 
 
 


### PR DESCRIPTION
## 💻 Are you changing functionalities?
#127 

### Description of the Change
- Replace default COLOR with Matplotlib colormap
- Determine font color based on relative luminance
- Add cmap, top_k and min_size arguments in both functions.

### Alternate Designs
- Matplotlib colormap can be used. (If set cmap to None, the original behavior remains the same.)
- The community by top_k, min_size or both can be filtered out.
- The color of the label is determined from the relative luminance of the node color.

### Possible Drawbacks
N/A

<details open>
<summary>I checked that it did not affect the original behavior.</summary>

```python
from cdlib import algorithms, viz
from networkx import generators 
import networkx as nx

g = generators.relaxed_caveman_graph(30, 3, .2, seed=123)
coms = algorithms.louvain(g)
pos = nx.spring_layout(g, k=0.5)
viz.plot_network_clusters(g, coms, pos, plot_labels=True, plot_overlaps=False)
viz.plot_network_clusters(g, coms, pos, plot_labels=True, plot_overlaps=True)
```

![image](https://user-images.githubusercontent.com/34591767/91022260-dfc06200-e62f-11ea-9169-422c7189167b.png)

</details>


### Verification Process
Passed test.

<details open>
<summary><b>cmap arg</b>: I checked the behavior by specifying NoneType, str or Matplotlib Colormap.</summary>

```python
G = nx.karate_club_graph()
coms = algorithms.louvain(G)
pos = nx.spring_layout(G, k=0.3)

# viz.plot_network_clusters(G, coms, pos, plot_overlaps=True, plot_labels=True, cmap=None)
# viz.plot_network_clusters(G, coms, pos, plot_overlaps=True, plot_labels=True, cmap="jet")
viz.plot_network_clusters(G, coms, pos, plot_overlaps=True, plot_labels=True, cmap=plt.cm.Wistia)
```

![cmap](https://user-images.githubusercontent.com/34591767/90707113-d05cb400-e2d1-11ea-8f47-e9a02e592c8d.png)

</details>


<details open>
<summary><b>top_k arg</b>: I checked that the graphs are filtered by specifing the following params.</summary>

![image](https://user-images.githubusercontent.com/34591767/91023888-18f9d180-e632-11ea-979f-89edb4d40edd.png)

Only the communities up to the specified number (=k) will be displayed.
![image](https://user-images.githubusercontent.com/34591767/91023831-05e70180-e632-11ea-8587-63b13b4a34e9.png)

</details>

<details open>
<summary><b>min_size arg</b>: I checked that the graphs are filtered by specifing the following params.</summary>

![image](https://user-images.githubusercontent.com/34591767/91024157-7ee65900-e632-11ea-93fa-0e833c77b230.png)

Similar to top_k , but the filter is determined by the number of nodes that belong to the community.
![image](https://user-images.githubusercontent.com/34591767/91024169-860d6700-e632-11ea-8d5f-5edcdc97a8e6.png)

I can’t make up my mind what to return when there are no communities that match the filter criteria.
Now, it returns [None](https://github.com/eternity1984/cdlib/blob/eea471781f08d8205d44c538de0cf3fc90134023/cdlib/viz/networks.py#L76).

</details>


### Release Notes
N/A