### PR TITLE
:bug: Implementation of AGDL

### DIFF
--- a/cdlib/algorithms/crisp_partition.py
+++ b/cdlib/algorithms/crisp_partition.py
@@ -259,16 +259,14 @@ def eigenvector(g_original):
     return NodeClustering(communities, g_original, "Eigenvector", method_parameters={"": ""})
 
 
-def agdl(g_original, number_communities, number_neighbors, kc, a):
+def agdl(g_original, number_communities, kc):
     """
     AGDL is a graph-based agglomerative algorithm, for clustering high-dimensional data.
     The algorithm uses  the indegree and outdegree to characterize the affinity between two clusters.
 
     :param g_original: a networkx/igraph object
     :param number_communities: number of communities
-    :param number_neighbors: Number of neighbors to use for KNN
     :param kc: size of the neighbor set for each cluster
-    :param a: range(-infinity;+infinty). From the authors: a=np.arange(-2,2.1,0.5)
     :return: NodeClustering object
 
      :Example:
@@ -276,7 +274,7 @@ def agdl(g_original, number_communities, number_neighbors, kc, a):
     >>> from cdlib import algorithms
     >>> import networkx as nx
     >>> G = nx.karate_club_graph()
-    >>> com = algorithms.agdl(g, number_communities=3, number_neighbors=3, kc=4, a=1)
+    >>> com = algorithms.agdl(g, number_communities=3, kc=4)
 
     :References:
 
@@ -287,15 +285,14 @@ def agdl(g_original, number_communities, number_neighbors, kc, a):
 
     g = convert_graph_formats(g_original, nx.Graph)
 
-    communities = Agdl(g, number_communities, number_neighbors, kc, a)
+    communities = Agdl(g, number_communities, kc)
     nodes = {k: v for k, v in enumerate(g.nodes())}
     coms = []
     for com in communities:
         coms.append([nodes[n] for n in com])
 
     return NodeClustering(coms, g_original, "AGDL", method_parameters={"number_communities": number_communities,
-                                                                       "number_neighbors": number_neighbors,
-                                                                       "kc": kc, "a": a})
+                                                                       "kc": kc})
 
 
 def louvain(g_original, weight='weight', resolution=1., randomize=False):

--- a/cdlib/algorithms/internal/AGDL.py
+++ b/cdlib/algorithms/internal/AGDL.py
@@ -11,8 +11,8 @@ def __knn(k, x):
     return distance, indices
 
 
-def __w_matrix(data, distance, indices, ks, a=10):
-    n = len(data)
+def __w_matrix(distance, indices, ks, a=10):
+    n = len(distance)
 
     weight_matrix = np.zeros([n, n])
 
@@ -21,21 +21,20 @@ def __w_matrix(data, distance, indices, ks, a=10):
     if ks == 1:
         for i in range(n):
             j = indices[i][0]
-            weight_matrix[i][j] = np.exp(-1 * (np.linalg.norm(data[i] - data[j]) ** 2) / sigma2)
+            weight_matrix[i][j] = np.exp(-1 * (distance[i,0] ** 2) / sigma2)
     else:
         for i in range(n):
-            for j in indices[i]:
-                weight_matrix[i][j] = np.exp(-1 * (np.linalg.norm(data[i] - data[j]) ** 2) / sigma2)
+            for k, j in enumerate(indices[i]):
+                weight_matrix[i][j] = np.exp(-1 * (distance[i,k] ** 2) / sigma2)
 
     return weight_matrix, sigma2
 
 
-def __k0graph(x, distance, indices, a=10):
-    w, sigma2 = __w_matrix(x, distance, indices, 1, a)
+def __k0graph(similarity):
+    x = np.arange(len(similarity))
+    y = [np.argmax(row) for row in similarity]
 
     vc = []
-
-    x, y = np.where(w > 0)
 
     for i in range(len(x)):
         x_index, y_index = -1, -1
@@ -45,7 +44,7 @@ def __k0graph(x, distance, indices, a=10):
             if x[i] in vc[k]:
                 x_index = k
 
-        if x_index == y_index:
+        if x_index == y_index and x_index != -1 and y_index != -1:
             continue
         elif x_index < 0 and y_index < 0:
             vc.append([x[i], y[i]])
@@ -109,18 +108,24 @@ def __get_neighbor(vc, kc, w):
 
     return ns, as_
 
-
-def Agdl(g, target_cluster_num, ks, kc, a):
-    data = nx.to_numpy_matrix(g)
+def preprocess(data, ks, a):
+    """
+    From data to graph.
+    __knn and __w_matrix only use for preprocess
+    """
     distance, indices = __knn(ks, data)
+    # convert distance to similarity
+    similarity, _ = __w_matrix(distance, indices, ks, a)
+    g = nx.from_numpy_matrix(similarity, create_using=nx.DiGraph)
+    return g
 
-    cluster = __k0graph(data, distance, indices, a)
-    length = 0
-    for i in range(len(cluster)):
-        length += len(cluster[i])
-
-    w, sigma = __w_matrix(data, distance, indices, ks, a)
-    neighbor_set, affinity_set = __get_neighbor(cluster, kc, w)
+def Agdl(g, target_cluster_num, kc):
+    similarity = nx.to_numpy_matrix(g)
+    # Using k0grpha to initilize cluster
+    
+    cluster = __k0graph(similarity)
+    
+    neighbor_set, affinity_set = __get_neighbor(cluster, kc, similarity)
     current_cluster_num = len(cluster)
 
     while current_cluster_num > target_cluster_num:
@@ -162,7 +167,7 @@ def Agdl(g, target_cluster_num, ks, kc, a):
                 continue
 
             if max_index1 in neighbor_set[i]:
-                aff_update = __get_affinity_btw_cluster(cluster[i], cluster[max_index1], w)
+                aff_update = __get_affinity_btw_cluster(cluster[i], cluster[max_index1], similarity)
 
                 p = neighbor_set[i].index(max_index1)
                 affinity_set[i][p] = aff_update  # fix the affinity values
@@ -174,7 +179,7 @@ def Agdl(g, target_cluster_num, ks, kc, a):
                 del affinity_set[i][p]
 
                 if max_index1 not in neighbor_set[i]:
-                    aff_update = __get_affinity_btw_cluster(cluster[i], cluster[max_index1], w)
+                    aff_update = __get_affinity_btw_cluster(cluster[i], cluster[max_index1], similarity)
                     neighbor_set[i].append(max_index1)
                     affinity_set[i].append(aff_update)
 
@@ -190,7 +195,7 @@ def Agdl(g, target_cluster_num, ks, kc, a):
 
         for i in range(len(neighbor_set[max_index1])):
             target_index = neighbor_set[max_index1][i]
-            new_affinity = __get_affinity_btw_cluster(cluster[target_index], cluster[max_index1], w)
+            new_affinity = __get_affinity_btw_cluster(cluster[target_index], cluster[max_index1], similarity)
             affinity_set[max_index1].append(new_affinity)
 
         if len(affinity_set[max_index1]) > kc:
@@ -210,8 +215,5 @@ def Agdl(g, target_cluster_num, ks, kc, a):
     for i in range(len(cluster)):
         if len(cluster[i]) != 0:
             reduced_cluster.append(cluster[i])
-    length = 0
-    for i in range(len(reduced_cluster)):
-        length += len(reduced_cluster[i])
 
     return reduced_cluster

--- a/cdlib/algorithms/internal/AGDL.py
+++ b/cdlib/algorithms/internal/AGDL.py
@@ -21,11 +21,11 @@ def __w_matrix(distance, indices, ks, a=10):
     if ks == 1:
         for i in range(n):
             j = indices[i][0]
-            weight_matrix[i][j] = np.exp(-1 * (distance[i,0] ** 2) / sigma2)
+            weight_matrix[i][j] = np.exp(-1 * (distance[i, 0] ** 2) / sigma2)
     else:
         for i in range(n):
             for k, j in enumerate(indices[i]):
-                weight_matrix[i][j] = np.exp(-1 * (distance[i,k] ** 2) / sigma2)
+                weight_matrix[i][j] = np.exp(-1 * (distance[i, k] ** 2) / sigma2)
 
     return weight_matrix, sigma2
 
@@ -108,6 +108,7 @@ def __get_neighbor(vc, kc, w):
 
     return ns, as_
 
+
 def preprocess(data, ks, a):
     """
     From data to graph.
@@ -119,12 +120,13 @@ def preprocess(data, ks, a):
     g = nx.from_numpy_matrix(similarity, create_using=nx.DiGraph)
     return g
 
+
 def Agdl(g, target_cluster_num, kc):
     similarity = nx.to_numpy_matrix(g)
     # Using k0grpha to initilize cluster
-    
+
     cluster = __k0graph(similarity)
-    
+
     neighbor_set, affinity_set = __get_neighbor(cluster, kc, similarity)
     current_cluster_num = len(cluster)
 

--- a/cdlib/test/test_community_discovery_models.py
+++ b/cdlib/test/test_community_discovery_models.py
@@ -406,7 +406,7 @@ class CommunityDiscoveryTests(unittest.TestCase):
 
     def test_agdl(self):
         g = get_string_graph()
-        coms = algorithms.agdl(g, 3, 2, 2, 0.5)
+        coms = algorithms.agdl(g, 3, 2)
         self.assertEqual(type(coms.communities), list)
         if len(coms.communities) > 0:
             self.assertEqual(type(coms.communities[0]), list)


### PR DESCRIPTION

### Identify the Bug
This links to issue #129 

The previous implementation of AGDL takes a graph as input and treats the adjacency matrix as data points.
The problem is the adjacency matrix is the pairwise similarity of data points hence should not be pass to function __knn() for finding its nearest neighbors.

### Description of the Change

The problem occurs when calling the following functions in Adgl,
__knn(): finding k-nearest neighbors for each data point.
_w_matrix: convert a distance matrix to a similarity matrix through gaussian kernel.
Hence, remove these two functions directly solve the problem. 

I did not modify the agglomerative clustering part in Adgl() except for a bug fix in __k0graph.
__k0graph: always return trivial result. (fix by checking initialization)

Add preprocess() calling __knn() and __w_matrix() for reproduce the result in the original paper on MNIST data but these three function are irrelevant to the core part of ADGL and can be removed.

### Alternate Designs

### Possible Drawbacks

### Verification Process

Reproduce the result stated in ADGL paper on MNIST data.

```python
import numpy as np
import pandas as pd
from AGDL import preprocess, Agdl
from sklearn.metrics import v_measure_score

# https://www.kaggle.com/oddrationale/mnist-in-csv
df_test = pd.read_csv('./MNIST/mnist_test.csv')
data, labels = df_test.iloc[::,1::], df_test['label']
    
k, a = 20, 20
g = preprocess(data, k, a)
# preprocess returns a nx.DiGraph object
cluster = Agdl(g, target_cluster_num=10, kc=10)

y_pred = np.zeros(len(data))-1
for idx, members in enumerate(cluster):
    y_pred[members] = idx
v_measure_score(labels, y_pred)
```
Test on my win10 laptop.
Score: 0.8393
Score stated in ADGL paper: 0.844

### Release Notes






