### PR TITLE
:memo: Fix expansion formula in docs [ci skip]

### DIFF
--- a/cdlib/evaluation/fitness.py
+++ b/cdlib/evaluation/fitness.py
@@ -466,7 +466,7 @@ def expansion(graph: nx.Graph, community: object, summary: bool = True) -> objec
 
     .. math:: f(S) = \\frac{c_S}{n_S}
 
-    where :math:`n_S` is the number of edges on the community boundary, :math:`c_S` is the number of community nodes.
+    where :math:`c_S` is the number of edges on the community boundary, :math:`n_S` is the number of community nodes.
 
     :param graph: a networkx/igraph object
     :param community: NodeClustering object


### PR DESCRIPTION
Docs for _Expansion_ evaluation metric was wrong. The terms c_s and n_s were inverted.

### Release Notes

Fix for evaluation metric _Expansion_ docs. Formula is now correct according to DOI 10.1007/s10115-013-0693-z

Closes #198 