### PR TITLE
:new: fix infomap import exception issue mentioned in #204

### DIFF
--- a/cdlib/algorithms/bipartite_clustering.py
+++ b/cdlib/algorithms/bipartite_clustering.py
@@ -3,6 +3,7 @@ import networkx as nx
 from cdlib.utils import convert_graph_formats
 from collections import defaultdict
 from cdlib.algorithms.internal.pycondor import condor_object, initial_community, brim
+from cdlib.prompt_utils import report_missing_packages, prompt_import_failure
 
 missing_packages = set()
 
@@ -11,6 +12,8 @@ try:
 except ModuleNotFoundError:
     missing_packages.add("infomap")
     imp = None
+except Exception as exception:
+    prompt_import_failure("infomap", exception)
 
 try:
     from wurlitzer import pipes
@@ -29,11 +32,7 @@ except ModuleNotFoundError:
     missing_packages.add("leidenalg")
     leidenalg = None
 
-if len(missing_packages) > 0:
-    print(
-        "Note: to be able to use all bipartite methods, you need to install some additional packages: ",
-        missing_packages,
-    )
+report_missing_packages(missing_packages)
 
 __all__ = ["bimlpa", "CPM_Bipartite", "infomap_bipartite", "condor"]
 

--- a/cdlib/algorithms/crisp_partition.py
+++ b/cdlib/algorithms/crisp_partition.py
@@ -33,6 +33,8 @@ from cdlib.algorithms.internal.paris import paris as paris_alg, paris_best_clust
 from cdlib.algorithms.internal.principled import principled
 from cdlib.algorithms.internal.MCODE import m_code
 from cdlib.algorithms.internal.RSC import rsc_evaluate_graph
+from cdlib.prompt_utils import report_missing_packages, prompt_import_failure
+
 import warnings
 
 import markov_clustering as mc
@@ -55,6 +57,8 @@ try:
 except ModuleNotFoundError:
     missing_packages.add("infomap")
     imp = None
+except Exception as exception:
+    prompt_import_failure("infomap", exception)
 
 try:
     from wurlitzer import pipes
@@ -85,11 +89,8 @@ except ModuleNotFoundError:
     missing_packages.add("karateclub")
 
 
-if len(missing_packages) > 0:
-    print(
-        "Note: to be able to use all crisp methods, you need to install some additional packages: ",
-        missing_packages,
-    )
+report_missing_packages(missing_packages)
+
 
 try:
     from GraphRicciCurvature.OllivierRicci import OllivierRicci

--- a/cdlib/algorithms/overlapping_partition.py
+++ b/cdlib/algorithms/overlapping_partition.py
@@ -32,7 +32,7 @@ from cdlib.algorithms.internal.EnDNTM import (
     endntm_find_overlap_cluster,
     endntm_evalFuction,
 )
-from cdlib.prompt_utils import report_missing_packages, prompt_import_failure
+from cdlib.prompt_utils import report_missing_packages
 
 import warnings
 

--- a/cdlib/algorithms/overlapping_partition.py
+++ b/cdlib/algorithms/overlapping_partition.py
@@ -32,6 +32,8 @@ from cdlib.algorithms.internal.EnDNTM import (
     endntm_find_overlap_cluster,
     endntm_evalFuction,
 )
+from cdlib.prompt_utils import report_missing_packages, prompt_import_failure
+
 import warnings
 
 missing_packages = set()
@@ -71,11 +73,7 @@ except ModuleNotFoundError:
     ASLPAw = None
     missing_packages.add("ASLPAw")
 
-if len(missing_packages) > 0:
-    print(
-        "Note: to be able to use all overlapping methods, you need to install some additional packages: ",
-        missing_packages,
-    )
+report_missing_packages(missing_packages)
 
 __all__ = [
     "ego_networks",

--- a/cdlib/prompt_utils.py
+++ b/cdlib/prompt_utils.py
@@ -1,0 +1,12 @@
+def report_missing_packages(package_list: list):
+    if len(package_list) > 0:
+        print(
+            "Note: to be able to use all crisp methods, you need to install some additional packages: ",
+            package_list,
+        )
+
+def prompt_import_failure(package: str, exception: Exception, show_details=False):
+    print("Note: cannot import package: %s" % str(package))
+    if show_details:
+        print("------> Detailed exception:")
+        print(exception)

--- a/cdlib/test/test_community_discovery_models.py
+++ b/cdlib/test/test_community_discovery_models.py
@@ -29,6 +29,8 @@ try:
     import infomap
 except ModuleNotFoundError:
     infomap = None
+except Exception as exception:
+    prompt_import_failure("infomap", exception)
 
 try:
     import graph_tool.all as gt


### PR DESCRIPTION
Hi cdlib authors,

Thanks for creating this usable graph package. This PR does not involve any algorithm change but extra exception capture for infomap and an prompt utils containing import failure user prompts. Please let me know if I need to make changes to follow your development regulations.

### Identify the Bug
described in #204 and #201 .


### Description of the Change
- refactor add prompt_utils, logically containing all user prompts, logs, etc
- capture Exception when importing infomap


### Verification Process

```
Python 3.8.12 | packaged by conda-forge | (default, Jan 30 2022, 23:36:06) 
[Clang 11.1.0 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from cdlib import algorithms
Note: cannot import package: infomap
Note: to be able to use all crisp methods, you need to install some additional packages:  {'graph_tool'}
Note: to be able to use all crisp methods, you need to install some additional packages:  {'ASLPAw'}
Note: cannot import package: infomap
>>> algorithms
<module 'cdlib.algorithms' from '/Users/random/cdlib/cdlib/algorithms/__init__.py'>
```
