### PR TITLE
Updating vizualisation of communities

### DIFF
--- a/cdlib/test/test_viz_network.py
+++ b/cdlib/test/test_viz_network.py
@@ -18,7 +18,12 @@ class NetworkVizTests(unittest.TestCase):
 
         coms = algorithms.demon(g, 0.25)
         pos = nx.spring_layout(g)
-        viz.plot_network_clusters(g, coms, pos, plot_labels=True, plot_overlaps=True)
+        viz.plot_network_clusters(g, coms, pos, 
+                                  plot_labels=True, 
+                                  plot_overlaps=True,
+                                  show_edge_weights=True,
+                                  show_edge_widths=True,
+                                  show_node_sizes=True)
 
         plt.savefig("cluster.pdf")
         os.remove("cluster.pdf")
@@ -33,7 +38,12 @@ class NetworkVizTests(unittest.TestCase):
         os.remove("cg.pdf")
 
         coms = algorithms.demon(g, 0.25)
-        viz.plot_community_graph(g, coms, plot_overlaps=True, plot_labels=True)
+        viz.plot_community_graph(g, coms, 
+                                 plot_labels=True, 
+                                 plot_overlaps=True,
+                                 show_edge_weights=True,
+                                 show_edge_widths=True,
+                                 show_node_sizes=True)
 
         plt.savefig("cg.pdf")
         os.remove("cg.pdf")

--- a/cdlib/viz/networks.py
+++ b/cdlib/viz/networks.py
@@ -291,7 +291,7 @@ def plot_community_graph(
     show_node_sizes: bool = True,
 ) -> object:
     """
-    Plot a algorithms-graph with node color coding for communities.
+    Plot a algorithms-graph with node color coding for communities, where nodes represent clusters obtained from a community detection algorithm.
 
     :param graph: NetworkX/igraph graph
     :param partition: NodeClustering object

--- a/cdlib/viz/networks.py
+++ b/cdlib/viz/networks.py
@@ -50,8 +50,8 @@ def plot_network_clusters(
     cmap: object = None,
     top_k: int = None,
     min_size: int = None,
-    show_edge_widths: bool = True,
-    show_edge_weights: bool = True,
+    show_edge_widths: bool = False,
+    show_edge_weights: bool = False,
 ) -> object:
     """
     Plot a graph with node color coding for communities.
@@ -60,13 +60,14 @@ def plot_network_clusters(
     :param partition: NodeClustering object
     :param position: A dictionary with nodes as keys and positions as values. Example: networkx.fruchterman_reingold_layout(G). By default, uses nx.spring_layout(g)
     :param figsize: the figure size; it is a pair of float, default (8, 8)
-    :param node_size: int, default 200
+    :param node_size: The size of nodes. It can be an integer or a dictionary mapping nodes to sizes. Default is 200.
     :param plot_overlaps: bool, default False. Flag to control if multiple algorithms memberships are plotted.
     :param plot_labels: bool, default False. Flag to control if node labels are plotted.
     :param cmap: str or Matplotlib colormap, Colormap(Matplotlib colormap) for mapping intensities of nodes. If set to None, original colormap is used.
     :param top_k: int, Show the top K influential communities. If set to zero or negative value indicates all.
     :param min_size: int, Exclude communities below the specified minimum size.
-    :param edge_weights: dict, dictionary containing edge weights
+    :param show_edge_widths: Flag to control if edge widths are shown. Default is False.
+    :param show_edge_weights: Flag to control if edge weights are shown. Default is False.
 
     Example:
 
@@ -247,12 +248,15 @@ def calculate_cluster_edge_weights(graph, node_to_com):
     cluster_edge_weights_array = [(source, target, weight) for (source, target), weight in cluster_edge_weights.items()]
     graph.add_weighted_edges_from(cluster_edge_weights_array)
 
-def calculate_cluster_sizes( c_graph: object ,partition: NodeClustering) -> Union[int, dict]:
+def calculate_cluster_sizes(partition: NodeClustering) -> Union[int, dict]:
     """
-    Calculate the number of nodes in each cluster.
+    Calculate the total weight of all nodes in each cluster.
 
-    :param partition: NodeClustering object
-    :return: Dictionary mapping cluster ID to the number of nodes in the cluster
+    :param partition: The partition of the graph into clusters.
+    :type partition: NodeClustering
+    :return: If all clusters have the same size, return the size as an integer.
+             Otherwise, return a dictionary mapping cluster ID to the number of nodes in the cluster.
+    :rtype: Union[int, dict]
     """
     cluster_sizes = {}
     unique_values = set()
@@ -267,9 +271,7 @@ def calculate_cluster_sizes( c_graph: object ,partition: NodeClustering) -> Unio
             else: # If node data is empty
                 total_weight += 1  # Default weight is 1
                 
-        cluster_sizes[cid] = total_weight
-        
-        print("TODO: ", c_graph[cid]) # TODO add weight to node of induced graph. 
+        cluster_sizes[cid] = total_weight      
         
     if len(unique_values) == 1:
         return int(unique_values.pop())  # All elements have the same value, return that value as an integer
@@ -296,13 +298,14 @@ def plot_community_graph(
     :param graph: NetworkX/igraph graph
     :param partition: NodeClustering object
     :param figsize: the figure size; it is a pair of float, default (8, 8)
-    :param node_size: int, default 200
+    :param node_size: The size of nodes. It can be an integer or a dictionary mapping nodes to sizes. Default is 200.
     :param plot_overlaps: bool, default False. Flag to control if multiple algorithms memberships are plotted.
     :param plot_labels: bool, default False. Flag to control if node labels are plotted.
     :param cmap: str or Matplotlib colormap, Colormap(Matplotlib colormap) for mapping intensities of nodes. If set to None, original colormap is used..
     :param top_k: int, Show the top K influential communities. If set to zero or negative value indicates all.
     :param min_size: int, Exclude communities below the specified minimum size.
-    :param show_edge_weights: Boolean, default is True. Flag to control displaying edge weights.
+    :param show_edge_widths: Flag to control if edge widths are shown. Default is True.
+    :param show_edge_weights: Flag to control if edge weights are shown. Default is True.
 
     Example:
 
@@ -340,7 +343,7 @@ def plot_community_graph(
     
     if node_size is None:
         # Calculate cluster sizes for adjusting node sizes
-        node_size = calculate_cluster_sizes(c_graph, partition)
+        node_size = calculate_cluster_sizes(partition)
 
     return plot_network_clusters(
         c_graph,


### PR DESCRIPTION
# Pull Request Vizualisation 

Collaborating with Remy Cazabet at UCBL(Université Claude Bernard Lyon1) to enrich CDLib's graph visualization.

ITJI Amine.

## 📝 Are you updating documentation?

### Description of the Change

I have updated the documentation for the `plot_network_clusters` and `plot_community_graph` functions to include information about the newly added parameters `show_edge_widths`, `show_edge_weights`, and `show_node_sizes`. These parameters enhance the modularity of graph visualization by allowing users to customize the display of node and edge sizes based on their weights, as well as display edge weights alongside the edges. Additionally, I have added documentation for the newly created functions `calculate_cluster_sizes` and `calculate_cluster_edge_weights`, which calculate the sizes of clusters and the weights of cluster edges, respectively.

### Release Notes

Updated documentation to include information about new parameters `show_edge_widths`, `show_edge_weights`, and `show_node_sizes` in `plot_network_clusters` and `plot_community_graph` functions for enhanced graph visualization customization.


## 💻 Are you changing functionalities?

![Figure_1](https://github.com/GiulioRossetti/cdlib/assets/100621612/e090c420-4a06-4300-b8b8-e8791b715004)

### Description of the Change

I have added the parameters `show_edge_widths`, `show_edge_weights`, and `show_node_sizes` to the `plot_network_clusters` and `plot_community_graph` functions in order to enhance the modularity of graph visualization. These parameters enable users to display nodes and edges with different sizes based on their weights, and to display edge weights alongside the edges. Consequently, I created the functions `calculate_cluster_sizes` and `calculate_cluster_edge_weights` to calculate the sizes of clusters and the weights of cluster edges, respectively.

### Alternate Designs

I considered implementing these functionalities directly within the `plot_network_clusters` and `plot_community_graph` functions, but opted for separate functions to maintain clarity and organization in the codebase.

### Possible Drawbacks

One possible drawback is an increased complexity for users due to the addition of these parameters and functions. Users may need to spend extra time understanding how to utilize these new features effectively.

### Verification Process

To verify the correctness of the changes, I performed the following steps:

- Tested the functionality locally with different combinations of parameter values.
- Ensured that the changes did not introduce any regressions by comparing the output of the visualizations with and without the new parameters.
- Reviewed the code changes and confirmed that they align with the proposed functionality.

### Release Notes

Added parameters `show_edge_widths`, `show_edge_weights`, and `show_node_sizes` to `plot_network_clusters` and `plot_community_graph` functions to enable more customizable graph visualizations.


