### PR TITLE
convert_graph_formats() handles networkx nodes that are neither strin…

### DIFF
--- a/cdlib/test/test_utils.py
+++ b/cdlib/test/test_utils.py
@@ -18,9 +18,50 @@ def get_string_graph():
     return g
 
 
+# networkx nodes just need to be Hashable:
+# this class is used in a test below that verifies
+# that such graphs can be converted into igraph
+class Node:
+    def __init__(self, id, type):
+        self.id = id
+        self.type = type
+
+    def __hash__(self):
+        return hash(self.id)
+
+    def __eq__(self, other):
+        return self.id == other.id
+
+
 class UtilsTests(unittest.TestCase):
     def test_convert(self):
         g = nx.karate_club_graph()
+        if ig is not None:
+            ign = utils.convert_graph_formats(g, ig.Graph)
+            self.assertEqual(g.number_of_nodes(), ign.vcount())
+            self.assertEqual(g.number_of_edges(), ign.ecount())
+
+            g2 = utils.convert_graph_formats(ign, nx.Graph)
+            self.assertEqual(g.number_of_nodes(), g2.number_of_nodes())
+            self.assertEqual(g.number_of_edges(), g2.number_of_edges())
+
+            g3 = utils.convert_graph_formats(g, nx.Graph)
+            self.assertEqual(isinstance(g, nx.Graph), isinstance(g3, nx.Graph))
+
+            g3 = utils.convert_graph_formats(ign, nx.Graph, directed=True)
+            self.assertIsInstance(g3, nx.DiGraph)
+
+    def test_convert_bipartite(self):
+        john = Node('John Travolta', 'actor')
+        nick = Node('Nick Cage', 'actor')
+        face_off = Node('Face Off', 'movie')
+
+        g = nx.Graph()
+        g.add_node(john)
+        g.add_node(nick)
+        g.add_edge(john, face_off, label='ACTED_IN')
+        g.add_edge(nick, face_off, label='ACTED_IN')
+
         if ig is not None:
             ign = utils.convert_graph_formats(g, ig.Graph)
             self.assertEqual(g.number_of_nodes(), ign.vcount())

--- a/cdlib/utils.py
+++ b/cdlib/utils.py
@@ -132,8 +132,9 @@ def __from_nx_to_igraph(g: object, directed: bool = None) -> object:
             gi.add_edges([("\\" + str(u), "\\" + str(v)) for (u, v) in g.edges()])
 
     if bipartite.is_bipartite(g) and not skip_bipartite:
+        convert = {str(x):x for x in g.nodes()}
         gi.vs["type"] = [
-            a_r[name] if type(name) == int else a_r[int(name.replace("\\", ""))]
+            a_r[name] if type(name) == int else a_r[convert[name.replace("\\", "")]]
             for name in gi.vs["name"]
         ]
 


### PR DESCRIPTION
…gs nor ints

### Identify the Bug

* Issue #241 

### Description of the Change

As mentioned on issue #241, this change handles the scenario where the graph nodes are neither strings nor ints. This is done in two steps:

1. A dictionary that maps from a string to the underlying node is constructed, and
2. That dictionary is used to properly handle the scenario where the input graph is bipartite.

### Alternate Designs

NA

### Possible Drawbacks

One issue with this fix is the extra memory required to construct the dictionary. But I don't see a way around this if supporting bipartite graphs is required.

### Verification Process

* Manual verification (running the repro test script with test changes),
* Added new test cases to `test_utils.py`.

### Release Notes

Correctly handled conversion from networkx to igraph format for bipartite graphs where nodes are neither strings nor ints.