### PR TITLE
Leiden resolution

### DIFF
--- a/cdlib/algorithms/crisp_partition.py
+++ b/cdlib/algorithms/crisp_partition.py
@@ -752,7 +752,7 @@ def rber_pots(
     ========== ======== ========
     Undirected Directed Weighted
     ========== ======== ========
-    Yes        No       No
+    Yes        No       Yes
     ========== ======== ========
 
 

--- a/cdlib/algorithms/crisp_partition.py
+++ b/cdlib/algorithms/crisp_partition.py
@@ -1081,7 +1081,7 @@ def greedy_modularity(g_original: object, weight: list = None) -> NodeClustering
     ========== ======== ========
     Undirected Directed Weighted
     ========== ======== ========
-    Yes        No       No
+    Yes        No       Yes
     ========== ======== ========
 
     :param g_original: a networkx/igraph object

--- a/cdlib/algorithms/crisp_partition.py
+++ b/cdlib/algorithms/crisp_partition.py
@@ -442,7 +442,7 @@ def eigenvector(g_original: object) -> NodeClustering:
     )
 
 
-def agdl(g_original: object, number_communities: int, kc: int) -> NodeClustering:
+def agdl(g_original: object, number_communities: int, kc: int, weight: str = "weight") -> NodeClustering:
     """
     AGDL is a graph-based agglomerative algorithm, for clustering high-dimensional data.
     The algorithm uses  the indegree and outdegree to characterize the affinity between two clusters.
@@ -459,6 +459,7 @@ def agdl(g_original: object, number_communities: int, kc: int) -> NodeClustering
     :param g_original: a networkx/igraph object
     :param number_communities: number of communities
     :param kc: size of the neighbor set for each cluster
+    :param weight: str, optional the key in graph to use as weight. Default to "weight"
     :return: NodeClustering object
 
      :Example:
@@ -477,7 +478,7 @@ def agdl(g_original: object, number_communities: int, kc: int) -> NodeClustering
 
     g = convert_graph_formats(g_original, nx.Graph)
 
-    communities = Agdl(g, number_communities, kc)
+    communities = Agdl(g, number_communities, kc, weight)
     nodes = {k: v for k, v in enumerate(g.nodes())}
     coms = []
     for com in communities:
@@ -487,7 +488,7 @@ def agdl(g_original: object, number_communities: int, kc: int) -> NodeClustering
         coms,
         g_original,
         "AGDL",
-        method_parameters={"number_communities": number_communities, "kc": kc},
+        method_parameters={"number_communities": number_communities, "kc": kc, "weight": weight},
     )
 
 

--- a/cdlib/algorithms/crisp_partition.py
+++ b/cdlib/algorithms/crisp_partition.py
@@ -574,7 +574,7 @@ def louvain(
 
 
 def leiden(
-    g_original: object, initial_membership: list = None, weights: list = None, seed: int = None
+    g_original: object, initial_membership: list = None, weights: list = None, resolution_parameter: float = 1.0, seed: int = None
 ) -> NodeClustering:
     """
     The Leiden algorithm is an improvement of the Louvain algorithm.
@@ -626,9 +626,10 @@ def leiden(
 
     part = leidenalg.find_partition(
         g,
-        leidenalg.ModularityVertexPartition,
+        leidenalg.RBConfigurationVertexPartition,
         initial_membership=initial_membership,
         weights=weights,
+        resolution_parameter=resolution_parameter,
         seed=seed,
     )
     coms = [g.vs[x]["name"] for x in part]
@@ -639,6 +640,7 @@ def leiden(
         method_parameters={
             "initial_membership": initial_membership,
             "weights": weights,
+            "resolution_parameter": resolution_parameter,
         },
     )
 

--- a/cdlib/algorithms/crisp_partition.py
+++ b/cdlib/algorithms/crisp_partition.py
@@ -847,7 +847,7 @@ def cpm(
     ========== ======== ========
     Undirected Directed Weighted
     ========== ======== ========
-    Yes        No       No
+    Yes        No       Yes
     ========== ======== ========
 
 

--- a/cdlib/algorithms/crisp_partition.py
+++ b/cdlib/algorithms/crisp_partition.py
@@ -595,6 +595,7 @@ def leiden(
     :param g_original: a networkx/igraph object
     :param initial_membership:  list of int Initial membership for the partition. If :obj:`None` then defaults to a singleton partition. Deafault None
     :param weights: list of double, or edge attribute Weights of edges. Can be either an iterable or an edge attribute. Deafault None
+    :param resolution_parameter: double >0 A parameter value controlling the coarseness of the clustering. Higher resolutions lead to more communities, while lower resolutions lead to fewer communities. Deafault 1
     :return: NodeClustering object
 
     :Example:

--- a/cdlib/algorithms/crisp_partition.py
+++ b/cdlib/algorithms/crisp_partition.py
@@ -1352,7 +1352,7 @@ def der(
     ========== ======== ========
     Undirected Directed Weighted
     ========== ======== ========
-    Yes        No       Yes
+    Yes        No       No
     ========== ======== ========
 
     :param g_original: an undirected networkx graph object

--- a/cdlib/algorithms/crisp_partition.py
+++ b/cdlib/algorithms/crisp_partition.py
@@ -1205,7 +1205,7 @@ def infomap(g_original: object, flags: str = "") -> NodeClustering:
     )
 
 
-def walktrap(g_original: object) -> NodeClustering:
+def walktrap(g_original: object, weights: str = None) -> NodeClustering:
     """
     walktrap is an approach based on random walks.
     The general idea is that if you perform random walks on the graph, then the walks are more likely to stay within the same community because there are only a few edges that lead outside a given community. Walktrap runs short random walks and uses the results of these random walks to merge separate communities in a bottom-up manner.
@@ -1216,10 +1216,11 @@ def walktrap(g_original: object) -> NodeClustering:
     ========== ======== ========
     Undirected Directed Weighted
     ========== ======== ========
-    Yes        No       No
+    Yes        No       Yes
     ========== ======== ========
 
     :param g_original: a networkx/igraph object
+    :param weights: label used for the edge weights. Default, None.
     :return: NodeClusterint object
 
     :Example:
@@ -1240,14 +1241,14 @@ def walktrap(g_original: object) -> NodeClustering:
         )
 
     g = convert_graph_formats(g_original, ig.Graph)
-    coms = g.community_walktrap().as_clustering()
+    coms = g.community_walktrap(weights=weights).as_clustering()
     communities = []
 
     for c in coms:
         communities.append([g.vs[x]["name"] for x in c])
 
     return NodeClustering(
-        communities, g_original, "Walktrap", method_parameters={"": ""}
+        communities, g_original, "Walktrap", method_parameters={"weights": weights}
     )
 
 

--- a/cdlib/algorithms/crisp_partition.py
+++ b/cdlib/algorithms/crisp_partition.py
@@ -1109,7 +1109,7 @@ def greedy_modularity(g_original: object, weight: list = None) -> NodeClustering
     )
 
 
-def infomap(g_original: object, flags: str = "") -> NodeClustering:
+def infomap(g_original: object, flags: str = "", weight: str = "weight") -> NodeClustering:
     """
     Infomap is based on ideas of information theory.
     The algorithm uses the probability flow of random walks on a network as a proxy for information flows in the real system and it decomposes the network into modules by compressing a description of the probability flow.
@@ -1126,6 +1126,7 @@ def infomap(g_original: object, flags: str = "") -> NodeClustering:
 
     :param g_original: a networkx/igraph object
     :param flags: str flags for Infomap
+    :param weight: str, optional the key in graph to use as weight. Default to "weight"
     :return: NodeClustering object
 
     :Example:
@@ -1150,7 +1151,8 @@ def infomap(g_original: object, flags: str = "") -> NodeClustering:
             import infomap as imp
         except ModuleNotFoundError:
             g = convert_graph_formats(g_original, ig.Graph)
-            coms = g.community_infomap()
+            edge_weights = weight if weight in g.es.attributes() else None
+            coms = g.community_infomap(edge_weights=edge_weights)
 
             communities = []
 
@@ -1158,7 +1160,7 @@ def infomap(g_original: object, flags: str = "") -> NodeClustering:
                 communities.append([g.vs[x]["name"] for x in c])
 
             return NodeClustering(
-                communities, g_original, "Infomap", method_parameters={"igraph": True}
+                communities, g_original, "Infomap", method_parameters={"igraph": True, "weight": edge_weights}
             )
             # raise ModuleNotFoundError(
             #    "Optional dependency not satisfied: install infomap to use the selected feature."
@@ -1190,8 +1192,8 @@ def infomap(g_original: object, flags: str = "") -> NodeClustering:
             im.add_nodes(g1.nodes)
 
         for source, target, data in g1.edges(data=True):
-            if "weight" in data:
-                im.add_link(source, target, data["weight"])
+            if weight in data:
+                im.add_link(source, target, data[weight])
             else:
                 im.add_link(source, target)
         im.run()
@@ -1202,7 +1204,7 @@ def infomap(g_original: object, flags: str = "") -> NodeClustering:
 
     coms_infomap = [list(c) for c in coms_to_node.values()]
     return NodeClustering(
-        coms_infomap, g_original, "Infomap", method_parameters={"flags": flags}
+        coms_infomap, g_original, "Infomap", method_parameters={"flags": flags, "weight": weight}
     )
 
 

--- a/cdlib/algorithms/internal/AGDL.py
+++ b/cdlib/algorithms/internal/AGDL.py
@@ -128,9 +128,9 @@ def preprocess(data, ks, a):
     return g
 
 
-def Agdl(g, target_cluster_num, kc):
+def Agdl(g, target_cluster_num, kc, weight):
     similarity = np.asmatrix(
-        nx.to_numpy_array(g)
+        nx.to_numpy_array(g,weight=weight)
     )  # , **kwargs)) #nx.to_numpy_matrix(g)
     # Using k0grpha to initilize cluster
 

--- a/cdlib/algorithms/internal/LSWL.py
+++ b/cdlib/algorithms/internal/LSWL.py
@@ -588,4 +588,5 @@ class LSWLPlusCommunityDetection:
                                     "weight", 0.0
                                 )
                         break
-            self.amend_partition_helper2(community, strength_dict)
+            if strength_dict:
+                self.amend_partition_helper2(community, strength_dict)

--- a/cdlib/algorithms/internal/UMSTMO.py
+++ b/cdlib/algorithms/internal/UMSTMO.py
@@ -27,31 +27,28 @@ def __union(vertice1, vertice2):
             rank[root2] += 1
 
 
-def UMSTMO(G):
+def UMSTMO(G, weight):
     G3 = nx.Graph()
-    # list of edges in la list T
-    T = list(G.edges())
 
-    i = 0
-    # joining each edge to its weight
     z2 = []
-    while i < len(T):
-        # z is number of common neighbors e(i,j)
-        z = len(list(nx.common_neighbors(G, T[i][0], T[i][1])))
-        # x the number of neighbors i and x1 for j
-        x = len(list(G.neighbors(T[i][0])))
-        x1 = len(list(G.neighbors(T[i][1])))
-        if z > 0:
-            # p is the value of jaccard coefficient
-            p = z / (x + x1 + z)
-            # add weight to the edge
-            G[T[i][0]][T[i][1]]["weight"] = p
-            # list of edges and their weights
-            z2.append([p, T[i][0], T[i][1]])
+    # if a weight attribute is specified, use it. Otherwise, calculate weights.
+    for u, v, d in G.edges(data=True):
+        if weight in d:
+            w = d[weight]
+            z2.append([w, u, v])
         else:
-            G[T[i][0]][T[i][1]]["weight"] = 0
-            z2.append([0, T[i][0], T[i][1]])
-        i = i + 1
+            # z is number of common neighbors e(i,j)
+            z = len(list(nx.common_neighbors(G, u, v)))
+            # x the number of neighbors i and x1 for j
+            x = G.degree(u)
+            x1 = G.degree(v)
+            if z > 0:
+                # p is the value of jaccard coefficient
+                p = z / (x + x1 + z)
+                # list of edges and their weights
+                z2.append([p, u, v])
+            else:
+                z2.append([0, u, v])
 
     for l in G.nodes():
         __make_set(l)

--- a/cdlib/algorithms/internal/lfm.py
+++ b/cdlib/algorithms/internal/lfm.py
@@ -8,58 +8,75 @@ New Journal of Physics 11.3 (2009): 033015.>>
 
 
 class Community(object):
-    def __init__(self, G, alpha=1.0):
+    def __init__(self, G, alpha=1.0, weight="weight"):
         self.g = G
         self.alpha = alpha
         self.nodes = set()
-        self.k_in = 0
-        self.k_out = 0
+        self.k_in = 0.0
+        self.k_out = 0.0
+        self.weight = weight
+
+    def _get_node_strengths(self, node):
+        node_k_in = 0.0
+        node_k_out = 0.0
+        for neighbor, data in self.g[node].items():
+            edge_weight = data.get(self.weight, 1.0)
+            if neighbor in self.nodes:
+                node_k_in += edge_weight
+            else:
+                node_k_out += edge_weight
+        return node_k_in, node_k_out
 
     def add_node(self, node):
-        neighbors = set(self.g.neighbors(node))
-        node_k_in = len(neighbors & self.nodes)
-        node_k_out = len(neighbors) - node_k_in
+        node_k_in, node_k_out = self._get_node_strengths(node)
         self.nodes.add(node)
         self.k_in += 2 * node_k_in
-        self.k_out = self.k_out + node_k_out - node_k_in
+        self.k_out += node_k_out - node_k_in
 
     def remove_vertex(self, node):
-        neighbors = set(self.g.neighbors(node))
-        community_nodes = self.nodes
-        node_k_in = len(neighbors & community_nodes)
-        node_k_out = len(neighbors) - node_k_in
+        # Note: Strengths must be calculated *before* removing the node
+        node_k_in, node_k_out = self._get_node_strengths(node)
         self.nodes.remove(node)
         self.k_in -= 2 * node_k_in
-        self.k_out = self.k_out - node_k_out + node_k_in
+        self.k_out -= node_k_out - node_k_in
 
     def cal_add_fitness(self, node):
-        neighbors = set(self.g.neighbors(node))
-        old_k_in = self.k_in
-        old_k_out = self.k_out
-        vertex_k_in = len(neighbors & self.nodes)
-        vertex_k_out = len(neighbors) - vertex_k_in
-        new_k_in = old_k_in + 2 * vertex_k_in
-        new_k_out = old_k_out + vertex_k_out - vertex_k_in
-        new_fitness = new_k_in / (new_k_in + new_k_out) ** self.alpha
-        old_fitness = old_k_in / (old_k_in + old_k_out) ** self.alpha
+        node_k_in, node_k_out = self._get_node_strengths(node)
+        new_k_in = self.k_in + 2 * node_k_in
+        new_k_out = self.k_out + node_k_out - node_k_in
+
+        if (self.k_in + self.k_out) == 0:
+            old_fitness = 0.0
+        else:
+            old_fitness = self.k_in / (self.k_in + self.k_out) ** self.alpha
+
+        if (new_k_in + new_k_out) == 0:
+            new_fitness = 0.0
+        else:
+            new_fitness = new_k_in / (new_k_in + new_k_out) ** self.alpha
+
         return new_fitness - old_fitness
 
     def cal_remove_fitness(self, node):
-        neighbors = set(self.g.neighbors(node))
-        new_k_in = self.k_in
-        new_k_out = self.k_out
-        node_k_in = len(neighbors & self.nodes)
-        node_k_out = len(neighbors) - node_k_in
-        old_k_in = new_k_in - 2 * node_k_in
-        old_k_out = new_k_out - node_k_out + node_k_in
-        old_fitness = old_k_in / (old_k_in + old_k_out) ** self.alpha
-        new_fitness = new_k_in / (new_k_in + new_k_out) ** self.alpha
-        return new_fitness - old_fitness
+        node_k_in, node_k_out = self._get_node_strengths(node)
+        
+        current_fitness = self.get_fitness()
+
+        new_k_in = self.k_in - 2 * node_k_in
+        new_k_out = self.k_out - (node_k_out - node_k_in)
+
+        if (new_k_in + new_k_out) == 0:
+            new_fitness = 0.0
+        else:
+            new_fitness = new_k_in / (new_k_in + new_k_out) ** self.alpha
+        
+        return current_fitness - new_fitness
 
     def recalculate(self):
         for vid in self.nodes:
-            fitness = self.cal_remove_fitness(vid)
-            if fitness < 0.0:
+            fitness_change = self.cal_remove_fitness(vid)
+            # If fitness increases after removal, it's a good candidate to remove
+            if fitness_change < 0.0:
                 return vid
         return None
 
@@ -70,19 +87,22 @@ class Community(object):
         return neighbors
 
     def get_fitness(self):
-        return float(self.k_in) / ((self.k_in + self.k_out) ** self.alpha)
+        if (self.k_in + self.k_out) == 0:
+            return 0.0
+        return self.k_in / ((self.k_in + self.k_out) ** self.alpha)
 
 
 class LFM_nx(object):
-    def __init__(self, G, alpha):
+    def __init__(self, G, alpha, weight="weight"):
         self.g = G
         self.alpha = alpha
+        self.weight = weight
 
     def execute(self):
         communities = []
-        node_not_include = list(self.g.nodes.keys())[:]
+        node_not_include = list(self.g.nodes())[:]
         while len(node_not_include) != 0:
-            c = Community(self.g, self.alpha)
+            c = Community(self.g, self.alpha, self.weight)
             # randomly select a seed node
             seed = random.choice(node_not_include)
             c.add_node(seed)

--- a/cdlib/algorithms/internal/walkscan.py
+++ b/cdlib/algorithms/internal/walkscan.py
@@ -5,11 +5,12 @@ from sklearn.cluster import DBSCAN
 
 
 class WalkSCAN(object):
-    def __init__(self, nb_steps=2, eps=0.1, min_samples=3):
+    def __init__(self, nb_steps=2, eps=0.1, min_samples=3, weight="weight"):
         self.nb_steps = nb_steps
         self.eps = eps
         self.min_samples = min_samples
         self.dbscan_ = DBSCAN(eps=self.eps, min_samples=self.min_samples)
+        self.weight = weight
 
     def load(self, graph, init_vector):
         self.graph = graph.copy()
@@ -21,11 +22,11 @@ class WalkSCAN(object):
             p[t + 1] = collections.defaultdict(int)
             for v in p[t]:
                 for (_, w, e_data) in self.graph.edges(v, data=True):
-                    if "weight" in e_data:
+                    if self.weight in e_data:
                         self.weighted_ = True
                         p[t + 1][w] += (
-                            float(e_data["weight"])
-                            / float(self.graph.degree(v, weight="weight"))
+                            float(e_data[self.weight])
+                            / float(self.graph.degree(v, weight=self.weight))
                             * p[t][v]
                         )
                     else:

--- a/cdlib/algorithms/overlapping_partition.py
+++ b/cdlib/algorithms/overlapping_partition.py
@@ -1683,6 +1683,7 @@ def umstmo(g_original: object) -> NodeClustering:
 
 def walkscan(
     g_original: object,
+    weight: str = "weight",
     nb_steps: int = 2,
     eps: float = 0.1,
     min_samples: int = 3,
@@ -1697,10 +1698,11 @@ def walkscan(
     ========== ======== ========
     Undirected Directed Weighted
     ========== ======== ========
-    Yes        No       No
+    Yes        No       Yes
     ========== ======== ========
 
     :param g_original: a networkx/igraph object
+    :param weight: name of the edge attribute containing the weights, default "weight"
     :param nb_steps: the length of the random walk
     :param eps: DBSCAN eps
     :param min_samples: DBSCAN min_samples
@@ -1722,7 +1724,7 @@ def walkscan(
     .. note:: Reference implementation: https://github.com/ahollocou/walkscan
     """
     g = convert_graph_formats(g_original, nx.Graph)
-    ws = WalkSCAN(nb_steps=nb_steps, eps=eps, min_samples=min_samples)
+    ws = WalkSCAN(nb_steps=nb_steps, eps=eps, min_samples=min_samples, weight=weight)
 
     # Initialization vector for the random walk
     if init_vector is None:
@@ -1741,6 +1743,7 @@ def walkscan(
             "eps": eps,
             "min_samples": min_samples,
             "init_vector": init_vector,
+            "weight": weight,
         },
         overlap=True,
     )

--- a/cdlib/algorithms/overlapping_partition.py
+++ b/cdlib/algorithms/overlapping_partition.py
@@ -475,7 +475,7 @@ def kclique(g_original: object, k: int) -> NodeClustering:
     )
 
 
-def lfm(g_original: object, alpha: float) -> NodeClustering:
+def lfm(g_original: object, alpha: float, weight: str = "weight") -> NodeClustering:
     """LFM is based on the local optimization of a fitness function.
     It finds both overlapping communities and the hierarchical structure.
 
@@ -485,11 +485,12 @@ def lfm(g_original: object, alpha: float) -> NodeClustering:
     ========== ======== ========
     Undirected Directed Weighted
     ========== ======== ========
-    Yes        No       No
+    Yes        No       Yes
     ========== ======== ========
 
     :param g_original: a networkx/igraph object
     :param alpha: parameter to controll the size of the communities:  Large values of alpha yield very small communities, small values instead deliver large modules. If alpha is small enough, all nodes end up in the same cluster, the network itself. In most cases, for alpha < 0.5 there is only one community, for alpha > 2 one recovers the smallest communities. A natural choise is alpha =1.
+    :param weight: name of the edge attribute containing the weights, default "weight"
     :return: NodeClustering object
 
     :Example:
@@ -502,15 +503,16 @@ def lfm(g_original: object, alpha: float) -> NodeClustering:
     :References:
 
     Lancichinetti, Andrea, Santo Fortunato, and János Kertész. `Detecting the overlapping and hierarchical community structure in complex networks <https://arxiv.org/abs/0802.1218/>`_ New Journal of Physics 11.3 (2009): 033015.
+    Lancichinetti, Andrea, and Santo Fortunato. Benchmarks for testing community detection algorithms on directed and weighted graphs with overlapping communities <https://arxiv.org/abs/0904.3940/>_ Physical Review E 80.1 (2009): 016118.
     """
 
     g = convert_graph_formats(g_original, nx.Graph)
 
-    algorithm = LFM_nx(g, alpha)
+    algorithm = LFM_nx(g, alpha, weight)
     coms = algorithm.execute()
 
     return NodeClustering(
-        coms, g_original, "LFM", method_parameters={"alpha": alpha}, overlap=True
+        coms, g_original, "LFM", method_parameters={"alpha": alpha, "weight": weight}, overlap=True
     )
 
 

--- a/cdlib/algorithms/overlapping_partition.py
+++ b/cdlib/algorithms/overlapping_partition.py
@@ -1243,7 +1243,7 @@ def aslpaw(g_original: object) -> NodeClustering:
     ========== ======== ========
     Undirected Directed Weighted
     ========== ======== ========
-    Yes        No       No
+    Yes        No       Yes
     ========== ======== ========
 
     :param g_original: a networkx/igraph object

--- a/cdlib/algorithms/overlapping_partition.py
+++ b/cdlib/algorithms/overlapping_partition.py
@@ -1574,7 +1574,7 @@ def dcs(g_original: object) -> NodeClustering:
     )
 
 
-def umstmo(g_original: object) -> NodeClustering:
+def umstmo(g_original: object, weight: str = "weight") -> NodeClustering:
     """
     Overlapping community detection based on the union of all maximum spanning trees
 
@@ -1584,10 +1584,11 @@ def umstmo(g_original: object) -> NodeClustering:
     ========== ======== ========
     Undirected Directed Weighted
     ========== ======== ========
-    Yes        No       No
+    Yes        No       Yes
     ========== ======== ========
 
     :param g_original: a networkx/igraph object
+    :param weight: name of the edge attribute containing the weights, default "weight"
     :return: NodeClustering object
 
     :Example:
@@ -1605,9 +1606,9 @@ def umstmo(g_original: object) -> NodeClustering:
 
     """
     g = convert_graph_formats(g_original, nx.Graph)
-    communities = UMSTMO(g)
+    communities = UMSTMO(g,weight=weight)
     return NodeClustering(
-        communities, g_original, "UMSTMO", method_parameters={}, overlap=True
+        communities, g_original, "UMSTMO", method_parameters={"weight":weight}, overlap=True
     )
 
 


### PR DESCRIPTION
Many docstrings were stating that an algorithm didn't support edge weights when it did (rber_pots, CPM, greedy_modularity, WALKSCAN, ASLPAw).

DER's docstring was incorrectly stating that it did support edge weights.

[igraph's walktrap](https://python.igraph.org/en/main/api/igraph.Graph.html#community_walktrap) can use edge weights but the cdlib wrapper simply wasn't exposing it.

The leiden wrapper was not providing access to the resolution_parameter.

Many weighted-graph-handling algorithms in this library do not expose the weight parameter, while some do. In this PR I try to improve consistency in that regard by exposing the weight parameter for Infomap and AGDL.

lswl_plus was crashing on my graphs and in this PR I provide a fix.

LFM and UMSTMO required relatively minor modifications to be able to use edge weights.

