### PR TITLE
LFM fix, sbm_dl/sbm_dl_nested fix

### DIFF
--- a/cdlib/algorithms/crisp_partition.py
+++ b/cdlib/algorithms/crisp_partition.py
@@ -1607,7 +1607,7 @@ def sbm_dl_nested(
     >>> from cdlib import algorithms
     >>> import networkx as nx
     >>> G = nx.karate_club_graph()
-    >>> coms = algorithms.sbm_dl(G)
+    >>> coms = algorithms.sbm_dl_nested(G)
 
 
     :References:

--- a/cdlib/algorithms/crisp_partition.py
+++ b/cdlib/algorithms/crisp_partition.py
@@ -175,7 +175,7 @@ def girvan_newman(g_original: object, level: int) -> NodeClustering:
     ========== ======== ========
 
     :param g_original: a networkx/igraph object
-    :param level: the level where to cut the dendrogram
+    :param level: the level where to cut the dendrogram (-1 for highest modularity)
     :return: NodeClustering object
 
     :Example:
@@ -194,8 +194,18 @@ def girvan_newman(g_original: object, level: int) -> NodeClustering:
 
     gn_hierarchy = nx.algorithms.community.girvan_newman(g)
     coms = []
-    for _ in range(level):
-        coms = next(gn_hierarchy)
+    if level==-1:
+        max_modularity = -float('inf')
+
+        for current_coms in gn_hierarchy:
+            mod = nx.algorithms.community.modularity(g, current_coms)
+            if mod > max_modularity:
+                max_modularity = mod
+                coms = current_coms
+    else:
+        for _ in range(level):
+            coms = next(gn_hierarchy)
+    
 
     communities = []
 

--- a/cdlib/algorithms/internal/LPAM.py
+++ b/cdlib/algorithms/internal/LPAM.py
@@ -39,7 +39,7 @@ def LPAM(graph, k=2, threshold=0.5, distance="amp", seed=0):
     Alexander Ponomarenko, Leonidas Pitsoulis, Marat Shamshetdinov
     """
 
-    def getCommuteDistace(G):
+    def getCommuteDistance(G):
         """
         Returns commute distance matrix
         """
@@ -112,7 +112,7 @@ def LPAM(graph, k=2, threshold=0.5, distance="amp", seed=0):
     if distance == "amp":
         D = getAmp(line_graph)
     if distance == "cm":
-        D = getCommuteDistace(line_graph)
+        D = getCommuteDistance(line_graph)
     if isinstance(distance, np.ndarray):
         D = distance
         distance_name = "custom"

--- a/cdlib/algorithms/internal/LPAM.py
+++ b/cdlib/algorithms/internal/LPAM.py
@@ -119,7 +119,7 @@ def LPAM(graph, k=2, threshold=0.5, distance="amp", seed=0):
     if D is None:
         raise TypeError('Parameter distance should be "amp"/"cm", or numpy.ndarray')
     _n = len(line_graph.nodes())
-    np.random.seed(0)
+    np.random.seed(seed)
     initial_medoids = np.random.choice(_n, k, replace=False)
     kmedoids_instance = kmedoids(D, initial_medoids, data_type="distance_matrix")
     # run cluster analysis and obtain results

--- a/cdlib/algorithms/internal/LPAM.py
+++ b/cdlib/algorithms/internal/LPAM.py
@@ -112,7 +112,7 @@ def LPAM(graph, k=2, threshold=0.5, distance="amp", seed=0):
     if distance == "amp":
         D = getAmp(line_graph)
     if distance == "cm":
-        D = getCommuteDistace
+        D = getCommuteDistace(line_graph)
     if isinstance(distance, np.ndarray):
         D = distance
         distance_name = "custom"

--- a/cdlib/algorithms/internal/lfm.py
+++ b/cdlib/algorithms/internal/lfm.py
@@ -100,7 +100,10 @@ class LFM_nx(object):
 
     def execute(self):
         communities = []
+        accepted_communities = set()
+        
         node_not_include = list(self.g.nodes())[:]
+        
         while len(node_not_include) != 0:
             c = Community(self.g, self.alpha, self.weight)
             # randomly select a seed node
@@ -128,8 +131,16 @@ class LFM_nx(object):
 
                 to_be_examined = c.get_neighbors()
 
-            for node in c.nodes:
-                if node in node_not_include:
-                    node_not_include.remove(node)
-            communities.append(list(c.nodes))
+            community_as_frozenset = frozenset(c.nodes)
+            
+            if community_as_frozenset in accepted_communities:
+                node_not_include.remove(seed)
+            else:
+                accepted_communities.add(community_as_frozenset)
+                communities.append(list(c.nodes))
+            
+                for node in c.nodes:
+                    if node in node_not_include:
+                        node_not_include.remove(node)
+                    
         return list(communities)

--- a/cdlib/utils.py
+++ b/cdlib/utils.py
@@ -278,7 +278,7 @@ def affiliations2nodesets(affiliations: dict) -> dict:
         return asNodeSets
 
     for n, coms in affiliations.items():
-        if isinstance(coms, str) or isinstance(coms, int) or isinstance(coms, np.int32):
+        if isinstance(coms, (str, int, np.integer)):
             coms = [coms]
         for c in coms:
             asNodeSets.setdefault(c, set())


### PR DESCRIPTION
Fixed a typo in the documentation of sbm_dl_nested where the code example was calling sbm_dl instead of sbm_dl_nested.

Fixed a utility function called by sbm_dl and sbm_dl_nested which would treat np_int64 as a list because the if statement was checking for np.int32 instead of np.integer. 

The LFM implementation could get stuck discovering the same communities in a loop. A fix is implemented by using a set and preventing such cycles. My understanding is this issue was present in the unweighted code but more likely to happen now that the weighted version was implemented in [this commit](https://github.com/GiulioRossetti/cdlib/commit/3191f659e9622145f307c938225b1c148c42269b).

Give a meaning to level==-1 for girvan-newman. With level==-1, the communities with the highest modularity will be returned. My understanding is that this is the standard way of using girvan-newman. We could even make level==-1 the default value for this parameter.

Fixed a serious typo in LPAM implementation causing crash if distance=='cm'. Also fixed typo causing seed parameter to be ignored.