### PR TITLE
Fixed EndNTM silently using weights to score solutions internally eve…

### DIFF
--- a/cdlib/algorithms/internal/EnDNTM.py
+++ b/cdlib/algorithms/internal/EnDNTM.py
@@ -17,7 +17,7 @@ def __bfs(graph, root, epsilon):
 
 
 def endntm_evalFuction(graph, clusters_list, etha=0.5):
-    mod = com.modularity(graph, clusters_list)
+    mod = com.modularity(graph, clusters_list, weight=None)
     coverage = nx.algorithms.community.partition_quality(graph, clusters_list)[0]
     val = (1 - etha) * coverage + etha * mod
     return val


### PR DESCRIPTION
EndNTM is an unweighted algorithm but it was scoring solutions using weights due to a library default parameter. This was not even coherent because it was mixing weighted modularity with unweighted coverage.
The problem is that com.modularity defaults to weight="weight"

### Release text

Fixed EndNTM silently partially using weights